### PR TITLE
LFLT-608 Update dependencies of TypeScript application stack

### DIFF
--- a/modules/binary-executable-agent/package.json
+++ b/modules/binary-executable-agent/package.json
@@ -7,7 +7,7 @@
     "livereload": "ts-node-dev --respawn --pretty --transpile-only ./src/bin-exec-agent-main.ts",
     "test": "jest",
     "build": "tsc --build . && tsc-alias -p tsconfig.json && ts-node ../../.circleci/generate-build-time.ts",
-    "package": "npx pkg --targets=linux --options max_old_space_size=64 --output=../../dist/domino-binary-executable-agent ../../dist"
+    "package": "npx pkg --targets=node18-linux --options max_old_space_size=64 --output=../../dist/domino-binary-executable-agent ../../dist"
   },
   "dependencies": {
     "axios": "1.6.8",


### PR DESCRIPTION
 - Switched back to NodeJS v18 for packaging the Binary Executable Agent due to incompatibility