### PR TITLE
LFLT-625 Implement deployment definitions viewer API

### DIFF
--- a/modules/coordinator/README.md
+++ b/modules/coordinator/README.md
@@ -544,6 +544,21 @@ DELETE /lifecycle/{app}/stop
 
 The endpoints above execute the corresponding lifecycle command on an already deployed application.
 
+## Deployment definition management
+
+```
+GET /deployments[?pageSize={pageSize}&pageNumber={pageNumber}]
+```
+
+Returns all registered deployments in a paginated form. Without specifying the page attributes (`pageSize` and `pageNumber`),
+returns the first 10 deployment definitions.
+
+```
+GET /deployments/{id}
+```
+
+Returns the identified deployment definition (or responds with `HTTP 404 Not Found` if missing).
+
 ## Websocket endpoint
 
 ```

--- a/modules/coordinator/package.json
+++ b/modules/coordinator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domino-platform/coordinator",
-  "version": "2.1.0-dev",
+  "version": "2.2.0-dev",
   "scripts": {
     "start": "ts-node ./src/coordinator-main.ts",
     "diststart": "node ../../dist/src/coordinator-main.js",

--- a/modules/coordinator/src/coordinator/core/config/deployment-config-module.ts
+++ b/modules/coordinator/src/coordinator/core/config/deployment-config-module.ts
@@ -73,6 +73,13 @@ export class DeploymentRegistry {
 
         return this.deployments.get(deploymentID)!;
     }
+
+    /**
+     * Returns all registered deployment definitions.
+     */
+    public getAllDeployments(): Deployment[] {
+        return Array.from(this.deployments.values());
+    }
 }
 
 /**
@@ -197,7 +204,7 @@ export class DeploymentConfigModule extends ConfigurationModule<DeploymentRegist
         const infoConfigSupplier: () => DeploymentInfo = () => {
             return {
                 endpoint: super.getMandatoryValue(info, "endpoint"),
-                fieldMapping: super.getValueAsMap(info, "field-mapping")!
+                fieldMapping: super.getValue(info, "field-mapping")!
             }
         }
 

--- a/modules/coordinator/src/coordinator/core/conversion/index.ts
+++ b/modules/coordinator/src/coordinator/core/conversion/index.ts
@@ -1,0 +1,18 @@
+import { DeploymentSummary } from "@coordinator/core/domain";
+import { Deployment } from "@core-lib/platform/api/deployment";
+
+/**
+ * Converts the given deployment definition (of type Deployment) to DeploymentSummary.
+ *
+ * @param deployment deployment definition to be converted
+ */
+export const deploymentSummaryConverter = (deployment: Deployment): DeploymentSummary => {
+
+    return {
+        id: deployment.id,
+        sourceType: deployment.source.type,
+        executionType: deployment.execution.via,
+        home: deployment.source.home,
+        resource: deployment.source.resource
+    }
+}

--- a/modules/coordinator/src/coordinator/core/dao/deployment-definition-dao.ts
+++ b/modules/coordinator/src/coordinator/core/dao/deployment-definition-dao.ts
@@ -1,0 +1,51 @@
+import { deploymentConfigModule, DeploymentRegistry } from "@coordinator/core/config/deployment-config-module";
+import { Page, PageAttributes } from "@coordinator/core/domain";
+import { Deployment } from "@core-lib/platform/api/deployment";
+
+/**
+ * DAO implementation for managing deployment definitions.
+ * Current implementation accesses definitions via the DeploymentRegistry, backed by the static deployment configuration file.
+ */
+export class DeploymentDefinitionDAO {
+
+    private readonly deploymentRegistry: DeploymentRegistry;
+
+    constructor(deploymentRegistry: DeploymentRegistry) {
+        this.deploymentRegistry = deploymentRegistry;
+    }
+
+    /**
+     * Returns all registered deployment definitions in a paginated manner.
+     *
+     * @param page wrapper for the page parameters
+     */
+    public async findAll(page: PageAttributes): Promise<Page<Deployment>> {
+
+        const allDeployments = this.deploymentRegistry
+            .getAllDeployments()
+            .sort((left, right) => left.id.localeCompare(right.id));
+        const offset = (page.page - 1) * page.limit;
+        const deploymentsOnPage = allDeployments.slice(offset, offset + page.limit);
+        const totalPages = Math.ceil(allDeployments.length / page.limit);
+
+        return {
+            itemCountOnPage: deploymentsOnPage.length,
+            pageSize: page.limit,
+            pageNumber: page.page,
+            totalItemCount: allDeployments.length,
+            totalPages,
+            items: deploymentsOnPage
+        }
+    }
+
+    /**
+     * Returns the registered deployment definition identified by the given deployment ID.
+     *
+     * @param id ID of the deployment to return, or undefined if not found
+     */
+    public async findOne(id: string): Promise<Deployment | undefined> {
+        return this.deploymentRegistry.getDeployment(id);
+    }
+}
+
+export const deploymentDefinitionDAO: DeploymentDefinitionDAO = new DeploymentDefinitionDAO(deploymentConfigModule.getConfiguration());

--- a/modules/coordinator/src/coordinator/core/domain/index.ts
+++ b/modules/coordinator/src/coordinator/core/domain/index.ts
@@ -1,7 +1,41 @@
+import { ExecutionType, SourceType } from "@core-lib/platform/api/deployment";
+
 /**
  * Internal domain class representing a deployment request.
  */
 export interface DeploymentAttributes {
     deployment: string;
     version?: string;
+}
+
+/**
+ * Internal domain class representing a set of page attributes.
+ */
+export interface PageAttributes {
+    page: number;
+    limit: number;
+}
+
+/**
+ * Internal domain class wrapping a page of items.
+ */
+export interface Page<T> {
+    pageNumber: number;
+    pageSize: number;
+    itemCountOnPage: number;
+    totalPages: number;
+    totalItemCount: number;
+    items: T[];
+}
+
+/**
+ * Internal domain class representing some base information of a deployment.
+ */
+export interface DeploymentSummary {
+
+    id: string;
+    sourceType: SourceType;
+    executionType: ExecutionType;
+    home: string;
+    resource: string;
 }

--- a/modules/coordinator/src/coordinator/core/service/deployment-definition-service.ts
+++ b/modules/coordinator/src/coordinator/core/service/deployment-definition-service.ts
@@ -1,0 +1,54 @@
+import { deploymentSummaryConverter } from "@coordinator/core/conversion";
+import { deploymentDefinitionDAO, DeploymentDefinitionDAO } from "@coordinator/core/dao/deployment-definition-dao";
+import { DeploymentSummary, Page } from "@coordinator/core/domain";
+import { UnknownDeploymentError } from "@coordinator/core/error/error-types";
+import { Deployment } from "@core-lib/platform/api/deployment";
+
+/**
+ * Service implementation controlling deployment definition related operations.
+ */
+export class DeploymentDefinitionService {
+
+    private readonly deploymentDefinitionDAO: DeploymentDefinitionDAO;
+
+    constructor(deploymentDefinitionDAO: DeploymentDefinitionDAO) {
+        this.deploymentDefinitionDAO = deploymentDefinitionDAO;
+    }
+
+    /**
+     * Returns all registered deployment definitions in a paginated manner.
+     *
+     * @param pageNumber number of the page to return (using 1-based index)
+     * @param pageSize maximum item count on a page
+     */
+    public async getDeploymentsPaged(pageNumber: number, pageSize: number): Promise<Page<DeploymentSummary>> {
+
+        return this.deploymentDefinitionDAO.findAll({
+            page: pageNumber,
+            limit: pageSize
+        }).then(page => {
+            return {
+                ...page,
+                items: page.items.map(deploymentSummaryConverter)
+            }
+        });
+    }
+
+    /**
+     * Returns the registered deployment definition identified by the given deployment ID.
+     *
+     * @param id ID of the deployment to return
+     * @throws UnknownDeploymentError if the requested definition does not exist
+     */
+    public async getDeployment(id: string): Promise<Deployment> {
+
+        const definition = await this.deploymentDefinitionDAO.findOne(id);
+        if (!definition) {
+            throw new UnknownDeploymentError(id);
+        }
+
+        return definition;
+    }
+}
+
+export const deploymentDefinitionService = new DeploymentDefinitionService(deploymentDefinitionDAO);

--- a/modules/coordinator/src/coordinator/core/service/info/info-response-processor.ts
+++ b/modules/coordinator/src/coordinator/core/service/info/info-response-processor.ts
@@ -37,7 +37,8 @@ export class InfoResponseProcessor {
 
         const infoDetailsMap = new Map<string, string>();
 
-        deploymentInfo.fieldMapping.forEach((path, key) => {
+        Object.keys(deploymentInfo.fieldMapping).forEach(key => {
+            const path = deploymentInfo.fieldMapping[key];
             const nodeValue = this.applyPath(response, path);
             if (!nodeValue) {
                 this.logger.warn(`Application info endpoint is misconfigured, retrieved no value on path=${path} - response will be deficient`);

--- a/modules/coordinator/src/coordinator/web/controller/controller.ts
+++ b/modules/coordinator/src/coordinator/web/controller/controller.ts
@@ -21,6 +21,7 @@ export interface Controller {
 export enum ControllerType {
     ACTUATOR = "actuator",
     AUTHENTICATION = "authentication",
+    DEPLOYMENTS = "deployments",
     LIFECYCLE = "lifecycle"
 }
 

--- a/modules/coordinator/src/coordinator/web/controller/deployments-controller.ts
+++ b/modules/coordinator/src/coordinator/web/controller/deployments-controller.ts
@@ -1,0 +1,56 @@
+import { DeploymentSummary } from "@coordinator/core/domain";
+import {
+    deploymentDefinitionService,
+    DeploymentDefinitionService
+} from "@coordinator/core/service/deployment-definition-service";
+import { Controller, ControllerType } from "@coordinator/web/controller/controller";
+import { pageConverter } from "@coordinator/web/conversion";
+import { PageRequest, PageResponse, ResponseWrapper } from "@coordinator/web/model/common";
+import { Validated } from "@coordinator/web/utility/validator";
+import { HttpStatus } from "@core-lib/platform/api/common";
+import { Deployment } from "@core-lib/platform/api/deployment";
+
+/**
+ * Controller implementation to handle deployment definition operations.
+ */
+export class DeploymentsController implements Controller {
+
+    private readonly deploymentDefinitionService: DeploymentDefinitionService;
+
+    constructor(deploymentDefinitionService: DeploymentDefinitionService) {
+        this.deploymentDefinitionService = deploymentDefinitionService;
+    }
+
+    /**
+     * GET /deployments[?pageSize={size}&pageNumber={number}]
+     * Returns all registered deployment definitions in a paginated manner.
+     *
+     * @param page wrapper for the optional page parameters, defaults to the first page, containing at most 10 items
+     */
+    @Validated()
+    async listDeployments(page: PageRequest): Promise<ResponseWrapper<PageResponse<DeploymentSummary>>> {
+
+        const deploymentPage = await this.deploymentDefinitionService.getDeploymentsPaged(page.page, page.size);
+
+        return new ResponseWrapper(HttpStatus.OK, pageConverter(deploymentPage));
+    }
+
+    /**
+     * GET /deployments/{id}
+     * Returns the registered deployment definitions identified by the given deployment ID.
+     *
+     * @param id ID of the deployment to return
+     */
+    async getDeployment(id: string): Promise<ResponseWrapper<Deployment>> {
+
+        const deployment = await this.deploymentDefinitionService.getDeployment(id);
+
+        return new ResponseWrapper(HttpStatus.OK, deployment);
+    }
+
+    controllerType(): ControllerType {
+        return ControllerType.DEPLOYMENTS;
+    }
+}
+
+export const deploymentsController = new DeploymentsController(deploymentDefinitionService);

--- a/modules/coordinator/src/coordinator/web/conversion/index.ts
+++ b/modules/coordinator/src/coordinator/web/conversion/index.ts
@@ -1,4 +1,5 @@
-import { DeploymentAttributes } from "@coordinator/core/domain";
+import { DeploymentAttributes, Page } from "@coordinator/core/domain";
+import { PageResponse } from "@coordinator/web/model/common";
 import { LifecycleRequest, LifecycleResponse, VersionedLifecycleRequest } from "@coordinator/web/model/lifecycle";
 import { OperationResult } from "@core-lib/platform/api/lifecycle";
 
@@ -41,4 +42,27 @@ export const operationResultConverter = (operationResult: OperationResult, proce
     }
 
     return lifecycleResponse;
+}
+
+/**
+ * Converts a Page object into PageResponse. Adds some additional, calculated page attributes, to make the response
+ * object compatible with Spring MVC based paginated responses.
+ *
+ * @param page Page object to be converted
+ */
+export const pageConverter = <T>(page: Page<T>): PageResponse<T> => {
+
+    return {
+        pagination: {
+            pageNumber: page.pageNumber,
+            pageCount: page.totalPages,
+            entityCount: page.totalItemCount,
+            entityCountOnPage: page.itemCountOnPage,
+            first: page.pageNumber === 1,
+            last: page.pageNumber === page.totalPages,
+            hasNext: page.pageNumber !== page.totalPages && page.pageNumber < page.totalPages,
+            hasPrevious: page.pageNumber > 1 && page.pageNumber <= page.totalPages + 1,
+        },
+        body: page.items
+    }
 }

--- a/modules/coordinator/src/coordinator/web/model/common.ts
+++ b/modules/coordinator/src/coordinator/web/model/common.ts
@@ -1,15 +1,17 @@
 import { HttpStatus } from "@core-lib/platform/api/common";
+import { Min } from "class-validator";
+import { Request } from "express";
 
 /**
  * Supported OAuth scopes.
  */
 export enum Scope {
+    READ_DEPLOYMENTS = "read:deployments",
     READ_INFO = "read:info",
     WRITE_DEPLOY = "write:deploy",
     WRITE_START = "write:start",
     WRITE_RESTART = "write:delete write:start",
-    WRITE_DELETE = "write:delete",
-    WRITE_UPLOAD = "write:upload"
+    WRITE_DELETE = "write:delete"
 }
 
 /**
@@ -52,4 +54,54 @@ export interface ErrorMessage {
 export interface ConstraintViolationErrorMessage extends ErrorMessage {
 
     violations: ConstraintViolation[];
+}
+
+/**
+ * Model wrapping the page parameters for paginated endpoints.
+ */
+export class PageRequest {
+
+    @Min(5)
+    readonly size: number;
+
+    @Min(1)
+    readonly page: number;
+
+    constructor(request: Request) {
+        this.size = this.parseQueryParameter(request, "pageSize", 10);
+        this.page = this.parseQueryParameter(request, "pageNumber", 1);
+    }
+
+    private parseQueryParameter(request: Request, key: string, defaultValue: number): number {
+
+        const value = request?.query?.[key] as string;
+
+        return value
+            ? parseInt(value)
+            : defaultValue;
+    }
+}
+
+/**
+ * Model representing the page attributes of a paginated response.
+ */
+export interface Pagination {
+
+    entityCount: number;
+    pageCount: number;
+    pageNumber: number;
+    entityCountOnPage: number;
+    first: boolean;
+    last: boolean;
+    hasNext: boolean;
+    hasPrevious: boolean;
+}
+
+/**
+ * Model wrapping the page attributes and the items on a page for paginated responses.
+ */
+export interface PageResponse<T> {
+
+    pagination: Pagination;
+    body: T[];
 }

--- a/modules/coordinator/tests/coordinator/core/config/deployment-config-module.test.ts
+++ b/modules/coordinator/tests/coordinator/core/config/deployment-config-module.test.ts
@@ -67,4 +67,24 @@ describe("Unit tests for DeploymentConfigModule", () => {
             expect(failingCall).toThrow(UnknownDeploymentError);
         });
     });
+
+    describe("Test scenarios for #getAllDeployments", () => {
+
+        // given
+        const deploymentRegistry = deploymentConfigModule.getConfiguration();
+
+        // when
+        const result = deploymentRegistry.getAllDeployments();
+
+        // then
+        expect(result.length).toBe(6);
+        expect(result).toStrictEqual([
+            dockerNoArgsDeployment,
+            dockerAllArgsDeployment,
+            dockerCustomDeployment,
+            filesystemServiceDeployment,
+            filesystemExecutableDeployment,
+            filesystemRuntimeDeployment
+        ])
+    });
 });

--- a/modules/coordinator/tests/coordinator/core/config/deployment.testdata.ts
+++ b/modules/coordinator/tests/coordinator/core/config/deployment.testdata.ts
@@ -89,10 +89,10 @@ export const dockerAllArgsDeployment: Deployment = {
     info: {
         enabled: true,
         endpoint: "http://127.0.0.1:9998/info",
-        fieldMapping: new Map<string, string>([
-            ["abbreviation", "$.app.abbreviation"],
-            ["version", "$.build.version"]
-        ])
+        fieldMapping: {
+            abbreviation: "$.app.abbreviation",
+            version: "$.build.version"
+        }
     }
 };
 
@@ -160,10 +160,10 @@ export const filesystemServiceDeployment: Deployment = {
     info: {
         enabled: true,
         endpoint: "http://127.0.0.1:9998/info",
-        fieldMapping: new Map<string, string>([
-            ["abbreviation", "$.app.abbreviation"],
-            ["version", "$.build.version"]
-        ])
+        fieldMapping: {
+            abbreviation: "$.app.abbreviation",
+            version: "$.build.version"
+        }
     }
 };
 

--- a/modules/coordinator/tests/coordinator/core/core.testdata.ts
+++ b/modules/coordinator/tests/coordinator/core/core.testdata.ts
@@ -1,5 +1,5 @@
 import { Agent } from "@coordinator/core/config/agent-config-module";
-import { DeploymentAttributes } from "@coordinator/core/domain";
+import { DeploymentAttributes, DeploymentSummary, Page } from "@coordinator/core/domain";
 import { Attempt } from "@coordinator/core/service/healthcheck";
 import { DeploymentInfoResponse, InfoStatus } from "@coordinator/core/service/info";
 import {
@@ -12,6 +12,7 @@ import {
 } from "@core-lib/platform/api/deployment";
 import { DeploymentStatus, OperationResult } from "@core-lib/platform/api/lifecycle";
 import { Announcement, Confirmation, Failure, MessageType, SocketMessage } from "@core-lib/platform/api/socket";
+import { dockerAllArgsDeployment } from "@testdata/deployment";
 
 export const deploymentAttributes: DeploymentAttributes = {
     deployment: "domino",
@@ -84,11 +85,11 @@ export const lastAttempt: Attempt = new Attempt({
 
 export const deploymentInfo: DeploymentInfo = {
     endpoint: "http://localhost:9999/info",
-    fieldMapping: new Map<string, string>([
-        ["appName", "$.app.name"],
-        ["abbreviation", "$.app.abbreviation"],
-        ["version", "$.build.version"]
-    ])
+    fieldMapping: {
+        appName: "$.app.name",
+        abbreviation: "$.app.abbreviation",
+        version: "$.build.version"
+    }
 }
 
 export const optionalDeploymentInfo: OptionalDeploymentInfo = {
@@ -198,4 +199,34 @@ export const confirmationSocketMessage: SocketMessage<Confirmation> = {
     payload: {
         message: `Agent accepted as [${agentLocalhostDocker.agentID}] with status [TRACKED]`
     }
+}
+
+export const deploymentSummary: DeploymentSummary = {
+    id: dockerAllArgsDeployment.id,
+    home: dockerAllArgsDeployment.source.home,
+    resource: dockerAllArgsDeployment.source.resource,
+    sourceType: dockerAllArgsDeployment.source.type,
+    executionType: dockerAllArgsDeployment.execution.via
+}
+
+export const pagedDeployments: Page<Deployment> = {
+    pageNumber: 2,
+    pageSize: 5,
+    itemCountOnPage: 1,
+    totalPages: 2,
+    totalItemCount: 6,
+    items: [
+        dockerAllArgsDeployment
+    ]
+}
+
+export const pagedDeploymentSummaries: Page<DeploymentSummary> = {
+    pageNumber: 2,
+    pageSize: 5,
+    itemCountOnPage: 1,
+    totalPages: 2,
+    totalItemCount: 6,
+    items: [
+        deploymentSummary
+    ]
 }

--- a/modules/coordinator/tests/coordinator/core/dao/deployment-definition-dao.test.ts
+++ b/modules/coordinator/tests/coordinator/core/dao/deployment-definition-dao.test.ts
@@ -1,0 +1,138 @@
+import { DeploymentRegistry } from "@coordinator/core/config/deployment-config-module";
+import { DeploymentDefinitionDAO } from "@coordinator/core/dao/deployment-definition-dao";
+import { Page } from "@coordinator/core/domain";
+import { Deployment } from "@core-lib/platform/api/deployment";
+import {
+    dockerAllArgsDeployment,
+    dockerCustomDeployment,
+    dockerNoArgsDeployment,
+    filesystemExecutableDeployment,
+    filesystemRuntimeDeployment,
+    filesystemServiceDeployment
+} from "@testdata/deployment";
+import sinon, { SinonStubbedInstance } from "sinon";
+
+describe("Unit tests for DeploymentDefinitionDAO", () => {
+
+    let deploymentRegistryMock: SinonStubbedInstance<DeploymentRegistry>;
+    let deploymentDefinitionDAO: DeploymentDefinitionDAO;
+
+    beforeEach(() => {
+        deploymentRegistryMock = sinon.createStubInstance(DeploymentRegistry);
+
+        deploymentDefinitionDAO = new DeploymentDefinitionDAO(deploymentRegistryMock);
+    });
+
+    describe("Test scenarios for #findAll", () => {
+
+        type Scenario = {
+            pageAttributes: { page: number, limit: number },
+            expectedPage: { itemCountOnPage: number, totalPages: number, items: Deployment[] }
+        }
+
+        const scenarios: Scenario[] = [
+            {
+                pageAttributes: {
+                    page: 1,
+                    limit: 4
+                },
+                expectedPage: {
+                    itemCountOnPage: 4,
+                    totalPages: 2,
+                    items: [
+                        dockerAllArgsDeployment,
+                        dockerCustomDeployment,
+                        dockerNoArgsDeployment,
+                        filesystemExecutableDeployment
+                    ]
+                },
+            },
+            {
+                pageAttributes: {
+                    page: 2,
+                    limit: 4
+                },
+                expectedPage: {
+                    itemCountOnPage: 2,
+                    totalPages: 2,
+                    items: [
+                        filesystemRuntimeDeployment,
+                        filesystemServiceDeployment
+                    ]
+                },
+            },
+            {
+                pageAttributes: {
+                    page: 1,
+                    limit: 10
+                },
+                expectedPage: {
+                    itemCountOnPage: 6,
+                    totalPages: 1,
+                    items: [
+                        dockerAllArgsDeployment,
+                        dockerCustomDeployment,
+                        dockerNoArgsDeployment,
+                        filesystemExecutableDeployment,
+                        filesystemRuntimeDeployment,
+                        filesystemServiceDeployment
+                    ]
+                },
+            },
+            {
+                pageAttributes: {
+                    page: 2,
+                    limit: 10
+                },
+                expectedPage: {
+                    itemCountOnPage: 0,
+                    totalPages: 1,
+                    items: []
+                },
+            }
+        ]
+
+        scenarios.forEach(scenario => {
+            it(`should return page of deployments with calculated page for page number ${scenario.pageAttributes.page} with limit ${scenario.pageAttributes.limit}`, async () => {
+
+                // given
+                const expectedPage: Page<Deployment> = {
+                    totalItemCount: 6,
+                    pageNumber: scenario.pageAttributes.page,
+                    pageSize: scenario.pageAttributes.limit,
+                    ...scenario.expectedPage
+                };
+
+                deploymentRegistryMock.getAllDeployments.returns([
+                    filesystemServiceDeployment,
+                    dockerCustomDeployment,
+                    dockerAllArgsDeployment,
+                    dockerNoArgsDeployment,
+                    filesystemRuntimeDeployment,
+                    filesystemExecutableDeployment
+                ]);
+
+                // when
+                const result = await deploymentDefinitionDAO.findAll(scenario.pageAttributes);
+
+                // then
+                expect(result).toStrictEqual(expectedPage);
+            });
+        })
+    });
+
+    describe("Test scenarios for #findOne", () => {
+
+        it("should return identified deployment from the registry", async () => {
+
+            // given
+            deploymentRegistryMock.getDeployment.withArgs(dockerAllArgsDeployment.id).resolves(dockerAllArgsDeployment);
+
+            // when
+            const result = await deploymentDefinitionDAO.findOne(dockerAllArgsDeployment.id);
+
+            // then
+            expect(result).toStrictEqual(dockerAllArgsDeployment);
+        });
+    });
+});

--- a/modules/coordinator/tests/coordinator/core/service/deployment-definition-service.test.ts
+++ b/modules/coordinator/tests/coordinator/core/service/deployment-definition-service.test.ts
@@ -1,0 +1,63 @@
+import { DeploymentDefinitionDAO } from "@coordinator/core/dao/deployment-definition-dao";
+import { UnknownDeploymentError } from "@coordinator/core/error/error-types";
+import { DeploymentDefinitionService } from "@coordinator/core/service/deployment-definition-service";
+import { pagedDeployments, pagedDeploymentSummaries } from "@testdata/core";
+import { dockerAllArgsDeployment } from "@testdata/deployment";
+import sinon, { SinonStubbedInstance } from "sinon";
+
+describe("Unit tests for DeploymentDefinitionService", () => {
+
+    let deploymentDefinitionDAOMock: SinonStubbedInstance<DeploymentDefinitionDAO>;
+    let deploymentDefinitionService: DeploymentDefinitionService;
+
+    beforeEach(() => {
+        deploymentDefinitionDAOMock = sinon.createStubInstance(DeploymentDefinitionDAO);
+
+        deploymentDefinitionService = new DeploymentDefinitionService(deploymentDefinitionDAOMock);
+    });
+
+    describe("Test scenarios for #getDeploymentsPaged", () => {
+
+        it("should return a page of deployments converted to summary objects", async () => {
+
+            // given
+            const page = 3;
+            const limit = 12;
+
+            deploymentDefinitionDAOMock.findAll.withArgs({ page, limit}).resolves(pagedDeployments);
+
+            // when
+            const result = await deploymentDefinitionService.getDeploymentsPaged(page, limit);
+
+            // then
+            expect(result).toStrictEqual(pagedDeploymentSummaries)
+        });
+    });
+
+    describe("Test scenarios for #getDeployment", () => {
+
+        it("should return identified deployment", async () => {
+
+            // given
+            deploymentDefinitionDAOMock.findOne.withArgs(dockerAllArgsDeployment.id).resolves(dockerAllArgsDeployment);
+
+            // when
+            const result = await deploymentDefinitionService.getDeployment(dockerAllArgsDeployment.id);
+
+            // then
+            expect(result).toStrictEqual(dockerAllArgsDeployment);
+        });
+
+        it("should raise error on unknown deployment", async () => {
+
+            // given
+            deploymentDefinitionDAOMock.findOne.withArgs(dockerAllArgsDeployment.id).resolves(undefined);
+
+            // when
+            const failingCall = async () => await deploymentDefinitionService.getDeployment(dockerAllArgsDeployment.id);
+
+            // then
+            await expect(failingCall).rejects.toThrow(UnknownDeploymentError);
+        });
+    });
+});

--- a/modules/coordinator/tests/coordinator/web/controller-registration.test.ts
+++ b/modules/coordinator/tests/coordinator/web/controller-registration.test.ts
@@ -3,6 +3,7 @@ import { ControllerRegistration } from "@coordinator/web/controller-registration
 import { ActuatorController } from "@coordinator/web/controller/actuator-controller";
 import { AuthenticationController } from "@coordinator/web/controller/authentication-controller";
 import { ControllerType } from "@coordinator/web/controller/controller";
+import { DeploymentsController } from "@coordinator/web/controller/deployments-controller";
 import { LifecycleController } from "@coordinator/web/controller/lifecycle-controller";
 import { Scope } from "@coordinator/web/model/common";
 import { AuthorizationHelper } from "@coordinator/web/utility/authorization-helper";
@@ -15,6 +16,7 @@ describe("Unit tests for ControllerRegistration", () => {
     let actuatorControllerMock: SinonStubbedInstance<ActuatorController>;
     let authenticationControllerMock: SinonStubbedInstance<AuthenticationController>;
     let lifecycleControllerMock: SinonStubbedInstance<LifecycleController>;
+    let deploymentControllerMock: SinonStubbedInstance<DeploymentsController>;
     let authorizationHelperMock: SinonStubbedInstance<AuthorizationHelper>;
     let authMock: SinonSpy;
     let controllerRegistration: ControllerRegistration;
@@ -28,13 +30,16 @@ describe("Unit tests for ControllerRegistration", () => {
         authenticationControllerMock.controllerType.returns(ControllerType.AUTHENTICATION);
         lifecycleControllerMock = sinon.createStubInstance(LifecycleControllerStub) as unknown as SinonStubbedInstance<LifecycleController>;
         lifecycleControllerMock.controllerType.returns(ControllerType.LIFECYCLE);
+        deploymentControllerMock = sinon.createStubInstance(DeploymentsControllerStub) as unknown as SinonStubbedInstance<DeploymentsController>;
+        deploymentControllerMock.controllerType.returns(ControllerType.DEPLOYMENTS)
         authorizationHelperMock = sinon.createStubInstance(AuthorizationHelper);
         authorizationHelperMock.prepareAuth.returns(scope => [() => authMock(scope)]);
 
         controllerRegistration = new ControllerRegistration([
             actuatorControllerMock,
             authenticationControllerMock,
-            lifecycleControllerMock
+            lifecycleControllerMock,
+            deploymentControllerMock
         ], authorizationHelperMock);
     });
 
@@ -60,6 +65,8 @@ describe("Unit tests for ControllerRegistration", () => {
             await _assertRegistration(result, "put", "/lifecycle", "/:deployment/start", lifecycleControllerMock.start, Scope.WRITE_START, 2);
             await _assertRegistration(result, "put", "/lifecycle", "/:deployment/restart", lifecycleControllerMock.restart, Scope.WRITE_RESTART, 2);
             await _assertRegistration(result, "delete", "/lifecycle", "/:deployment/stop", lifecycleControllerMock.stop, Scope.WRITE_DELETE, 2);
+            await _assertRegistration(result, "get", "/deployments", "/", deploymentControllerMock.listDeployments, Scope.READ_DEPLOYMENTS, 2);
+            await _assertRegistration(result, "get", "/deployments", "/:id", deploymentControllerMock.getDeployment, Scope.READ_DEPLOYMENTS, 2);
 
             parameterlessHelperStub.restore();
             parameterizedHelperStub.restore();
@@ -171,5 +178,11 @@ class LifecycleControllerStub {
     async start(): Promise<void> {}
     async stop(): Promise<void> {}
     async restart(): Promise<void> {}
+    controllerType(): any {};
+}
+
+class DeploymentsControllerStub {
+    async listDeployments(): Promise<void> {}
+    async getDeployment(): Promise<void> {}
     controllerType(): any {};
 }

--- a/modules/coordinator/tests/coordinator/web/controller/deployments-controller.test.ts
+++ b/modules/coordinator/tests/coordinator/web/controller/deployments-controller.test.ts
@@ -1,0 +1,89 @@
+import { DeploymentDefinitionService } from "@coordinator/core/service/deployment-definition-service";
+import { ControllerType } from "@coordinator/web/controller/controller";
+import { DeploymentsController } from "@coordinator/web/controller/deployments-controller";
+import { InvalidRequestError } from "@coordinator/web/error/api-error-types";
+import { HttpStatus } from "@core-lib/platform/api/common";
+import { pagedDeploymentSummaries } from "@testdata/core";
+import { dockerAllArgsDeployment } from "@testdata/deployment";
+import { invalidPageRequest, pageRequest, pageRequestWithDefaults, pageResponse } from "@testdata/web";
+import sinon, { SinonStubbedInstance } from "sinon";
+
+describe("Unit tests for DeploymentsController", () => {
+
+    let deploymentDefinitionServiceMock: SinonStubbedInstance<DeploymentDefinitionService>;
+    let deploymentsController: DeploymentsController;
+
+    beforeEach(() => {
+        deploymentDefinitionServiceMock = sinon.createStubInstance(DeploymentDefinitionService);
+        deploymentsController = new DeploymentsController(deploymentDefinitionServiceMock);
+    });
+
+    describe("Test scenarios for #listDeployments", () => {
+
+        it("should list existing deployments with given paging", async () => {
+
+            // given
+            deploymentDefinitionServiceMock.getDeploymentsPaged.withArgs(pageRequest.page, pageRequest.size)
+                .resolves(pagedDeploymentSummaries);
+
+            // when
+            const result = await deploymentsController.listDeployments(pageRequest);
+
+            // then
+            expect(result.content).toStrictEqual(pageResponse);
+            expect(result.status).toStrictEqual(HttpStatus.OK);
+        });
+
+        it("should list existing deployments with default paging", async () => {
+
+            // given
+            deploymentDefinitionServiceMock.getDeploymentsPaged.withArgs(1, 10)
+                .resolves(pagedDeploymentSummaries);
+
+            // when
+            const result = await deploymentsController.listDeployments(pageRequestWithDefaults);
+
+            // then
+            expect(result.content).toStrictEqual(pageResponse);
+            expect(result.status).toStrictEqual(HttpStatus.OK);
+        });
+
+        it("should fail with validation error", async () => {
+
+            // when
+            const failingCall = async () => await deploymentsController.listDeployments(invalidPageRequest);
+
+            // then
+            await expect(failingCall).rejects.toThrow(InvalidRequestError);
+        });
+    });
+
+    describe("Test scenarios for #getDeployment", () => {
+
+        it("should return identified deployment", async () => {
+
+            // given
+            deploymentDefinitionServiceMock.getDeployment.withArgs(dockerAllArgsDeployment.id)
+                .resolves(dockerAllArgsDeployment);
+
+            // when
+            const result = await deploymentsController.getDeployment(dockerAllArgsDeployment.id);
+
+            // then
+            expect(result.content).toStrictEqual(dockerAllArgsDeployment);
+            expect(result.status).toStrictEqual(HttpStatus.OK);
+        });
+    });
+
+    describe("Test scenarios for #controllerType", () => {
+
+        it("should return ControllerType.DEPLOYMENTS", () => {
+
+            // when
+            const result = deploymentsController.controllerType();
+
+            // then
+            expect(result).toBe(ControllerType.DEPLOYMENTS);
+        });
+    });
+});

--- a/modules/coordinator/tests/coordinator/web/utility/mapping-helper.test.ts
+++ b/modules/coordinator/tests/coordinator/web/utility/mapping-helper.test.ts
@@ -102,6 +102,24 @@ describe("Unit tests for mapping helper functions", () => {
             sinon.assert.calledWithMatch(responseStub.json, lifecycleRequest);
         });
 
+        it("should successfully map primitive parameter from Express request", async () => {
+
+            // given
+            const id = "leaflet"
+            requestStub = {
+                params: { id }
+            } as unknown as Request;
+            const parameterizedMappingHelper = new ParameterizedMappingHelper<string>((request: Request) => request.params.id);
+
+            // when
+            const result = parameterizedMappingHelper.register(async (id) => new ResponseWrapper<string>(HttpStatus.OK, id));
+            await result(requestStub, responseStub, () => { });
+
+            // then
+            sinon.assert.calledWith(responseStub.status, HttpStatus.OK);
+            sinon.assert.calledWithMatch(responseStub.json, id);
+        });
+
         it("should handle input mapping errors", async () => {
 
             // given

--- a/modules/coordinator/tests/coordinator/web/web.testdata.ts
+++ b/modules/coordinator/tests/coordinator/web/web.testdata.ts
@@ -1,8 +1,11 @@
 import { AppInfoConfig } from "@coordinator/core/config/app-info-config-module";
+import { DeploymentSummary } from "@coordinator/core/domain";
 import { InfoResponse } from "@coordinator/web/model/actuator";
 import { DirectAuthRequest, DirectAuthResponse } from "@coordinator/web/model/authentication";
+import { PageRequest, PageResponse } from "@coordinator/web/model/common";
 import { LifecycleRequest, LifecycleResponse, VersionedLifecycleRequest } from "@coordinator/web/model/lifecycle";
 import { DeploymentStatus } from "@core-lib/platform/api/lifecycle";
+import { deploymentSummary } from "@testdata/core";
 import { Request } from "express";
 import { hrtime } from "node:process";
 import sinon from "sinon";
@@ -73,4 +76,36 @@ export const directAuthRequestInvalid = new DirectAuthRequest({} as unknown as R
 
 export const directAuthResponse: DirectAuthResponse = {
     jwt: "jwt-token-1"
+}
+
+export const pageRequest = new PageRequest({
+    query: {
+        pageSize: 5,
+        pageNumber: 2
+    }
+} as unknown as Request);
+
+export const pageRequestWithDefaults = new PageRequest({} as unknown as Request);
+
+export const invalidPageRequest = new PageRequest({
+    query: {
+        pageSize: 3,
+        pageNumber: 0
+    }
+} as unknown as Request);
+
+export const pageResponse: PageResponse<DeploymentSummary> = {
+    pagination: {
+        pageNumber: 2,
+        pageCount: 2,
+        entityCount: 6,
+        entityCountOnPage: 1,
+        hasNext: false,
+        hasPrevious: true,
+        first: false,
+        last: true
+    },
+    body: [
+        deploymentSummary
+    ]
 }

--- a/modules/platform-core/package.json
+++ b/modules/platform-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domino-platform/platform-core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "test": "jest",
     "build": "tsc --build . && tsc-alias -p tsconfig.json"

--- a/modules/platform-core/src/lib/platform/api/deployment/index.ts
+++ b/modules/platform-core/src/lib/platform/api/deployment/index.ts
@@ -85,7 +85,7 @@ export interface DeploymentExecution {
 export interface DeploymentInfo {
 
     endpoint: string;
-    fieldMapping: Map<string, string>;
+    fieldMapping: MapLikeObject;
 }
 
 /**

--- a/modules/platform-core/src/lib/platform/config/index.ts
+++ b/modules/platform-core/src/lib/platform/config/index.ts
@@ -113,20 +113,4 @@ export abstract class ConfigurationModule<T, CK extends string> {
 
         return value;
     }
-
-    /**
-     * Extracts a specific configuration value as a string-string map from the given configuration node.
-     *
-     * @param parameters contents of the currently inspected configuration node
-     * @param key configuration key
-     * @protected can only be used by concrete implementations
-     */
-    protected getValueAsMap(parameters: MapNode, key: CK): Map<string, string> | undefined {
-
-        const value = this.getValue(parameters, key);
-
-        return value
-            ? new Map<string, string>(Object.entries(value))
-            : undefined;
-    }
 }

--- a/modules/platform-core/tests/lib/platform/config/configuration-module.test.ts
+++ b/modules/platform-core/tests/lib/platform/config/configuration-module.test.ts
@@ -13,7 +13,6 @@ describe("Unit tests for ConfigurationModule", () => {
             interface Dummy {
                 keyMandatory: string;
                 keyOptional: string;
-                keyMap: Map<string, string>;
                 keyEmbedded: string;
                 keyList: { key5: string, key6: string }[]
             }
@@ -24,7 +23,6 @@ describe("Unit tests for ConfigurationModule", () => {
                         return {
                             keyMandatory: super.getMandatoryValue(mapNode, "key1"),
                             keyOptional: super.getValue(mapNode, "key2"),
-                            keyMap: super.getValueAsMap(mapNode, "map-node")!,
                             keyEmbedded: super.getValue(super.getNode(mapNode, "map-node"), "key3"),
                             keyList: (super.getValue(mapNode, "list-node") as [])
                                 .map(item => {
@@ -48,10 +46,6 @@ describe("Unit tests for ConfigurationModule", () => {
             expect(result).toStrictEqual({
                 keyMandatory: "value1",
                 keyOptional: undefined,
-                keyMap: new Map<string, string>([
-                    ["key3", "value3"],
-                    ["key4", "value4"]
-                ]),
                 keyEmbedded: "value3",
                 keyList: [
                     { key5: "value5", key6: "value6" }
@@ -130,7 +124,7 @@ describe("Unit tests for ConfigurationModule", () => {
             class DummyModule extends ConfigurationModule<Dummy, "key-1"> {
 
                 constructor() {
-                    super("logging", mapNode => {
+                    super("logging", _ => {
                         return {
                             key1: super.getValue(undefined, "key-1", "key-1-default")
                         };
@@ -156,7 +150,7 @@ describe("Unit tests for ConfigurationModule", () => {
             class DummyModule extends ConfigurationModule<object, "key"> {
 
                 constructor() {
-                    super("dummy", mapNode => {
+                    super("dummy", _ => {
                         return {};
                     });
                 }
@@ -180,7 +174,7 @@ describe("Unit tests for ConfigurationModule", () => {
             class DummyModule extends ConfigurationModule<object, "key"> {
 
                 constructor() {
-                    super("logging", mapNode => {
+                    super("logging", _ => {
                         throw new Error("Something went wrong");
                     });
 
@@ -208,7 +202,7 @@ describe("Unit tests for ConfigurationModule", () => {
             class DummyModule extends ConfigurationModule<object, "key"> {
 
                 constructor() {
-                    super("logging", mapNode => {
+                    super("logging", _ => {
                         throw new Error("Something went wrong");
                     }, loggerMock);
 


### PR DESCRIPTION
 - Implemented base DAO for deployment definition management
 - Implemented deployment definition management API with read-only operations
 - Added unit tests
 - Bumped Coordinator version to 2.2.0-dev
 - Changed field mapping attribute type in deployment definition to map-like object
 - Bumped Platform Core version to 1.2.0