### PR TITLE
LFLT-656 Make Domino support multi-instance deployments

### DIFF
--- a/modules/coordinator/README.md
+++ b/modules/coordinator/README.md
@@ -36,14 +36,16 @@ specifically for your deployment definitions, but they can also be accessed remo
     8. [Coordinator info configuration](#coordinator-info-configuration)
 4. [Deployments configuration](#deployments-configuration)
     1. [Source configuration](#source-configuration)
-    2. [Execution configuration](#execution-configuration)
+    2. [Target configuration](#target-configuration)
+        1. [Multi-instance configuration](#multi-instance-configuration)
+    3. [Execution configuration](#execution-configuration)
         1. [Execution types](#execution-types)
         2. [Execution arguments for Docker deployments](#execution-arguments-for-docker-deployments)
-    3. [Health-check configuration](#health-check-configuration)
-    4. [Application info endpoint configuration](#application-info-endpoint-configuration)
-    5. [Using secrets](#using-secrets)
-    6. [Configuration examples](#configuration-examples)
-    7. [Required configuration parameters by execution type](#required-configuration-parameters-by-execution-type)
+    4. [Health-check configuration](#health-check-configuration)
+    5. [Application info endpoint configuration](#application-info-endpoint-configuration)
+    6. [Using secrets](#using-secrets)
+    7. [Configuration examples](#configuration-examples)
+    8. [Required configuration parameters by execution type](#required-configuration-parameters-by-execution-type)
 5. [Registering applications in an OAuth 2.0 Authorization Server](#registering-applications-in-an-oauth-20-authorization-server)
    1. [Behavior directives](#behavior-directives)
    2. [Tenant directives](#tenant-directives)
@@ -312,14 +314,54 @@ here in the following format: `<host>:<port>[/<optional-group-name>]`.
 
 ## Target configuration
 
-Target configuration determines the actual server instance, where your application is running.
+Target configuration determines the actual server instance where your application is running. You may also define some 
+directives for deploying multiple instances of the application on different hosts.
 
-| Parameter | Description                                                                   |
-|-----------|-------------------------------------------------------------------------------|
-| `hosts`   | List of arbitrary host IDs, where you would like to install your application. |
+| Parameter                               | Description                                                                                 |
+|-----------------------------------------|---------------------------------------------------------------------------------------------|
+| `hosts`                                 | List of arbitrary host IDs, where you would like to install your application.               |
+| `multi-instance.enabled`                | Enables multi-instance deployment.                                                          |
+| `multi-instance.instance-count`         | Sets the number of deployed instances.                                                      |
+| `multi-instance.spread-mode`            | Controls how the instances should be spread across multiple hosts.                          |
+| `multi-instance.naming-strategy`        | Controls how to derive the instance names of the deployment command name.                   |
+| `multi-instance.defined-names`          | List of the predefined custom instance names (for `custom-predefined` naming strategy).     |
+| `multi-instance.port-offset`            | Port offset (e.g. +100, -200, etc.) to derive instance ports from the defined base port(s). |
+| `multi-instance.host-network-base-port` | Base port number for "host" Docker networking mode.                                         |
 
-Please note, that by deploying the same application on multiple hosts, the necessary load balancing should be configured
+Please note that by deploying the same application on multiple hosts, the necessary load balancing should be configured
 in your own load balancer solution (e.g. Apache HTTPD, nginx, etc.).
+
+### Multi-instance configuration
+
+It is possible to configure an application to have multiple instances deployed either on the same host or on different
+hosts to spread the load. Please note that this feature is currently available for Docker deployments only. Below 
+you'll find some help on how to set the configuration parameters described above.
+
+* `instance-count`: Determines the total number of instances that should be deployed.
+* `spread-mode`:  
+  * `replicate`: Regardless how many target hosts are specified (even if it's only one), the same set of instances will be
+deployed on all of them. Let's say the instance count is set to 3 and you have 2 different target hosts, you'll have 6
+deployed instances in total.
+  * `one-per-host`: Deploys one instance per target host. In this case, `instance-count` must match the number of target hosts.
+* `naming-strategy`:  
+  * `incremental-suffix`: An incremental 0-based suffix is appended to the command name of each instance. E.g. the command
+name is `myapp` and you set the `instance-count` to 3, Domino will deploy the following instances: `myapp-0`, `myapp-1` and `myapp-2`.
+  * `custom-predefined`: Domino will append the predefined suffixes to the command name of each instance. E.g. the command
+name is `myapp` and you set the `instance-count` to 2 and the predefined suffixes are `primary` and `standby`, Domino will
+deploy the following instances: `myapp-primary` and `myapp-standby`. (The `instance-count` parameter must match the number 
+of predefined suffixes in this case.)
+* `defined-names`: List of the predefined custom instance names (for `custom-predefined` naming strategy).
+* `port-offset`: You can define an offset value (a negative or positive integer) to derive instance ports from the defined
+base port(s). In case you are using `host` network mode, the port offset is applied against the `host-network-base-port`
+parameter. Otherwise, the port offset is applied against the exposed ports.
+* `host-network-base-port`: Base port number for `host` Docker networking mode. Since port exposure is ignored for `host`
+network mode, the calculated port number will be added to the deployment as an environment variable called `INSTANCE_PORT`.
+
+The port numbers are going to form an increasing (or decreasing) sequence per each instance, e.g. `myapp-0` will have 
+port 8080, `myapp-1` will have port 8180, `myapp-2` will have port 8280, etc., assuming you have a `port-offset` of +100, 
+a port exposure of 8080 and your application is using a bridged network. The same applies to the `INSTANCE_PORT` 
+environment variable in case of `host` network mode, but then the base port is determined by the `host-network-base-port` 
+parameter.
 
 ## Execution configuration
 
@@ -715,17 +757,18 @@ non-expired access token, provided as `Authorization: Bearer <token>` header par
 ## Lifecycle management commands
 
 ```
-GET /lifecycle/{app}/info
+GET /lifecycle/{app}/info[?instance=<instance-suffix>]
 ```
 
 Returns information about the running instance of the specified application. Data returned on this endpoint can (and must)
-be configured as part of the deployment configuration.
+be configured as part of the deployment configuration. For multi-instance deployments, you must use the `instance` query
+parameter to select a specific instance.
 
 ```
-PUT /lifecycle/{app}/deploy[/{version}]
+PUT /lifecycle/{app}/deploy[/{version}][?roll=<true|false>][&instance=<instance-suffix>]
 ```
 
-Deploy endpoint can be used to prepare the selected version of an application for execution. E.g. for filesystem based 
+Deploy endpoint can be used to prepare the selected version of an application for execution. E.g. for filesystem-based  
 application sources, it means that the executable is copied from the storage to the app's home directory, and it is also
 renamed to its expected filename.
 
@@ -733,22 +776,31 @@ Version is optional here - in case it is not provided, the latest uploaded versi
 case please check the response of the endpoint, as it contains the actually deployed version (along with some other
 information, please see below).
 
+For multi-instance deployments, you may use the `roll` query parameter to instruct Domino to deploy, start and run
+health check against all instances one after another. With the `instance` query parameter you may limit the deployment
+operation to a specific intance (without automatically starting up the instance). Neither of these switches is allowed
+against single-instance deployments.
+
 ```
-PUT /lifecycle/{app}/start
-PUT /lifecycle/{app}/restart
-DELETE /lifecycle/{app}/stop
+PUT /lifecycle/{app}/start[?roll=<true|false>][&instance=<instance-suffix>]
+PUT /lifecycle/{app}/restart[?roll=<true|false>][&instance=<instance-suffix>]
+DELETE /lifecycle/{app}/stop[?roll=<true|false>][&instance=<instance-suffix>]
 ```
+
+For multi-instance deployments, you may use the `roll` query parameter to instruct Domino to start/stop/restart (and run 
+health check against) all instances one after another. With the `instance` query parameter you may limit the lifecycle 
+operation to a specific intance. Neither of these switches is allowed against single-instance deployments.
 
 The endpoints above execute the corresponding lifecycle command on an already deployed application.
 
 **Response structure**
 
-Response of lifecycle commands always contain:
+Response of lifecycle commands always contains:
  * a custom message, usually also containing the elapsed time in milliseconds, that was required to execute the command;
  * also a deployment status value, which provides more accurate insight of what happened due to the command execution;
  * and deploy endpoint also returns the deployed version. 
 
-As an example a response would look like this:
+As an example, a response would look like this:
 
 ```
 {
@@ -1008,6 +1060,9 @@ Agents may connect to this endpoint, using `ws://` or `wss://` protocol.
 For any of the endpoints above it is also possible that `403 Forbidden` is returned in case your JWT token is missing, invalid or expired.
 
 # Changelog
+
+**v2.5.0-6**
+* Introduced support for multi-instance deployments
 
 **v2.4.0-5**
 * Introducing a new experimental feature, adding capability to register OAuth 2.0 client or resource server applications

--- a/modules/coordinator/config/test.yml
+++ b/modules/coordinator/config/test.yml
@@ -48,6 +48,12 @@ domino:
       target:
         hosts:
           - localhost
+        multi-instance:
+          enabled: true
+          instance-count: 2
+          naming-strategy: incremental-suffix
+          spread-mode: replicate
+          port-offset: +100
       execution:
         command-name: app_docker_no_args
         via: STANDARD
@@ -64,6 +70,16 @@ domino:
       target:
         hosts:
           - localhost
+        multi-instance:
+          enabled: true
+          instance-count: 2
+          naming-strategy: custom-predefined
+          defined-names:
+            - primary
+            - standby
+          spread-mode: replicate
+          port-offset: +200
+          host-network-base-port: 9000
       execution:
         command-name: app_docker_all_args
         via: STANDARD
@@ -102,6 +118,18 @@ domino:
       target:
         hosts:
           - localhost
+          - host2
+          - host3
+        multi-instance:
+          enabled: true
+          instance-count: 3
+          naming-strategy: custom-predefined
+          defined-names:
+            - instance-1
+            - instance-2
+            - instance-3
+          spread-mode: one-per-host
+          port-offset: 0
       execution:
         command-name: app_docker_custom
         via: STANDARD

--- a/modules/coordinator/package.json
+++ b/modules/coordinator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domino-platform/coordinator",
-  "version": "2.4.0-dev",
+  "version": "2.5.0-dev",
   "scripts": {
     "start": "ts-node ./src/coordinator-main.ts",
     "diststart": "node ../../dist/src/coordinator-main.js",

--- a/modules/coordinator/src/coordinator/core/config/deployment/abstract-deployment-config-module.ts
+++ b/modules/coordinator/src/coordinator/core/config/deployment/abstract-deployment-config-module.ts
@@ -10,8 +10,11 @@ import {
     DockerExecutionType,
     EnabledDeploymentOperation,
     FilesystemExecutionType,
+    InstanceNamingStrategy,
+    InstanceSpreadMode,
     OptionalDeploymentHealthcheck,
     OptionalDeploymentInfo,
+    OptionalMultiInstanceDeployment,
     SourceType,
     validIDMatcher
 } from "@core-lib/platform/api/deployment";
@@ -23,7 +26,8 @@ import { ILogObj, Logger } from "tslog";
 
 type DeploymentKey = "source" | "target" | "execution" | "health-check" | "info";
 type DeploymentSourceKey = "type" | "home" | "resource";
-type DeploymentTargetKey = "hosts";
+type DeploymentTargetKey = "hosts" | "multi-instance";
+type MultiInstanceTypeKey = "instance-count" | "spread-mode" | "naming-strategy" | "defined-names" | "port-offset" | "host-network-base-port";
 type DeploymentExecutionKey = "via" | "command-name" | "as-user" | "args" | "runtime";
 type DeploymentDockerExecutionKey =
     "restart-policy"
@@ -41,6 +45,7 @@ type DeploymentKeyCompound =
     DeploymentKey
     | DeploymentSourceKey
     | DeploymentTargetKey
+    | MultiInstanceTypeKey
     | DeploymentExecutionKey
     | DeploymentDockerExecutionKey
     | DeploymentOptionalOperationKey
@@ -95,12 +100,38 @@ export abstract class AbstractDeploymentConfigModule<T> extends ConfigurationMod
         };
     }
 
+    private mapMultiInstanceConfig(target: MapNode): OptionalMultiInstanceDeployment {
+
+        const multiInstanceConfig = super.getNode(target, "multi-instance");
+
+        if (!multiInstanceConfig || !this.getValue(multiInstanceConfig, "enabled")) {
+            return { enabled: false };
+        }
+
+        const hostNetworkBasePort = super.getValue(multiInstanceConfig, "host-network-base-port") as string | undefined;
+
+        return {
+            enabled: true,
+            instanceCount: super.getValue(multiInstanceConfig, "instance-count") as number,
+            spreadMode: InstanceSpreadMode[this.extractEnumField(multiInstanceConfig, "spread-mode") as keyof typeof InstanceSpreadMode],
+            namingStrategy: InstanceNamingStrategy[this.extractEnumField(multiInstanceConfig, "naming-strategy") as keyof typeof InstanceNamingStrategy],
+            definedNames: (super.getValue(multiInstanceConfig, "defined-names") ?? []) as string[],
+            portOffset: parseInt(super.getValue(multiInstanceConfig, "port-offset", 0) as string),
+            hostNetworkBasePort: hostNetworkBasePort ? parseInt(hostNetworkBasePort) : undefined,
+        };
+    }
+
+    private extractEnumField(multiInstanceConfig: MapNode, fieldName: MultiInstanceTypeKey): string {
+        return (super.getValue(multiInstanceConfig, fieldName) as string).toUpperCase().replaceAll('-', '_');
+    }
+
     private mapDeploymentTarget(deployment: MapNode): DeploymentTarget {
 
         const target = super.getNode(deployment, "target");
 
         return {
-            hosts: super.getMandatoryValue(target, "hosts")
+            hosts: super.getMandatoryValue(target, "hosts"),
+            multiInstance: this.mapMultiInstanceConfig(target),
         };
     }
 

--- a/modules/coordinator/src/coordinator/core/config/deployment/loader.ts
+++ b/modules/coordinator/src/coordinator/core/config/deployment/loader.ts
@@ -74,6 +74,34 @@ const deepCopyObject = (sourceObject: unknown): unknown => {
 
 const jsonDataFixes: DataFix[] = [
     {
+        source: (definition: any) => definition.target?.multiInstance,
+        target: (definition: any, extractedValue: any) => definition.target["multi-instance"] = extractedValue
+    },
+    {
+        source: (definition: any) => definition.target?.multiInstance?.instanceCount,
+        target: (definition: any, extractedValue: any) => definition.target["multi-instance"]["instance-count"] = extractedValue
+    },
+    {
+        source: (definition: any) => definition.target?.multiInstance?.spreadMode,
+        target: (definition: any, extractedValue: any) => definition.target["multi-instance"]["spread-mode"] = extractedValue
+    },
+    {
+        source: (definition: any) => definition.target?.multiInstance?.namingStrategy,
+        target: (definition: any, extractedValue: any) => definition.target["multi-instance"]["naming-strategy"] = extractedValue
+    },
+    {
+        source: (definition: any) => definition.target?.multiInstance?.definedNames,
+        target: (definition: any, extractedValue: any) => definition.target["multi-instance"]["defined-names"] = extractedValue
+    },
+    {
+        source: (definition: any) => definition.target?.multiInstance?.portOffset,
+        target: (definition: any, extractedValue: any) => definition.target["multi-instance"]["port-offset"] = extractedValue
+    },
+    {
+        source: (definition: any) => definition.target?.multiInstance?.hostNetworkBasePort,
+        target: (definition: any, extractedValue: any) => definition.target["multi-instance"]["host-network-base-port"] = extractedValue
+    },
+    {
         source: (definition: any) => definition.execution?.asUser,
         target: (definition: any, extractedValue: any) => definition.execution["as-user"] = extractedValue
     },

--- a/modules/coordinator/src/coordinator/core/conversion/index.ts
+++ b/modules/coordinator/src/coordinator/core/conversion/index.ts
@@ -65,6 +65,13 @@ export const yamlExporter = (deployment: Deployment): DeploymentExport => {
     const id = deployment.id;
     const reformattedDeployment: any = applyJSONDataFix(deployment);
     delete reformattedDeployment.domino.deployments[id].id;
+    delete reformattedDeployment.domino.deployments[id].target.multiInstance;
+    delete reformattedDeployment.domino.deployments[id].target["multi-instance"].instanceCount;
+    delete reformattedDeployment.domino.deployments[id].target["multi-instance"].spreadMode;
+    delete reformattedDeployment.domino.deployments[id].target["multi-instance"].namingStrategy;
+    delete reformattedDeployment.domino.deployments[id].target["multi-instance"].definedNames;
+    delete reformattedDeployment.domino.deployments[id].target["multi-instance"].hostNetworkBasePort;
+    delete reformattedDeployment.domino.deployments[id].target["multi-instance"].portOffset;
     delete reformattedDeployment.domino.deployments[id].execution?.asUser;
     delete reformattedDeployment.domino.deployments[id].execution?.commandName;
     delete reformattedDeployment.domino.deployments[id].execution?.args?.commandArgs;

--- a/modules/coordinator/src/coordinator/core/domain/index.ts
+++ b/modules/coordinator/src/coordinator/core/domain/index.ts
@@ -6,6 +6,8 @@ import { ExecutionType, SourceType } from "@core-lib/platform/api/deployment";
 export interface DeploymentAttributes {
     deployment: string;
     version?: string;
+    roll: boolean;
+    instance?: string;
 }
 
 /**

--- a/modules/coordinator/src/coordinator/core/domain/operation-queue.ts
+++ b/modules/coordinator/src/coordinator/core/domain/operation-queue.ts
@@ -1,0 +1,93 @@
+import { DeploymentStatus, OperationResult } from "@core-lib/platform/api/lifecycle";
+import LoggerFactory from "@core-lib/platform/logging";
+
+/**
+ * Queue for executing deployment operations in sequence.
+ */
+export class OperationQueue {
+
+    private readonly logger = LoggerFactory.getLogger(OperationQueue);
+    private readonly errorStates = [
+        DeploymentStatus.DEPLOY_FAILED_MISSING_VERSION,
+        DeploymentStatus.DEPLOY_FAILED_UNKNOWN,
+        DeploymentStatus.HEALTH_CHECK_FAILURE,
+        DeploymentStatus.INVALID_REQUEST,
+        DeploymentStatus.START_FAILURE,
+        DeploymentStatus.STOP_FAILURE,
+        DeploymentStatus.TIMEOUT
+    ];
+
+    private readonly queue: (() => Promise<OperationResult>)[] = [];
+    private readonly deploymentID: string;
+    private lastResult: OperationResult | undefined;
+
+    private constructor(deploymentID: string) {
+        this.deploymentID = deploymentID;
+    }
+
+    /**
+     * Creates a new OperationQueue instance.
+     *
+     * @param deploymentID ID of the deployment for which the queue is created
+     */
+    public static create(deploymentID: string): OperationQueue {
+        return new OperationQueue(deploymentID);
+    }
+
+    /**
+     * Returns the result of the last deployment operation.
+     */
+    public get lastOperationResult(): OperationResult {
+
+        if (!this.lastResult) {
+            throw new Error(`No lifecycle operation result available for deployment [${this.deploymentID}]`);
+        }
+
+        return this.lastResult;
+    }
+
+    /**
+     * Enqueues the given operation to be executed in sequence.
+     *
+     * @param operation deployment operation to be executed
+     */
+    public enqueue(operation: () => Promise<OperationResult>): void {
+        this.queue.push(operation);
+    }
+
+    /**
+     * Executes all operations in the queue in sequence.
+     */
+    public async execute(): Promise<OperationResult> {
+
+        if (this.queue.length === 0) {
+            throw new Error("No lifecycle operations to execute");
+        }
+
+        this.logger.info(`Executing lifecycle operations for deployment [${this.deploymentID}]`);
+        const totalSteps = this.queue.length;
+        let currentStep = 1;
+
+        do {
+            const operation = this.queue.shift();
+            if (!operation) {
+                throw new Error("Lifecycle operation not found");
+            }
+
+            this.lastResult = await operation();
+
+            if (this.errorStates.includes(this.lastOperationResult.status)) {
+                this.logger.error(`Lifecycle operation ${currentStep}/${totalSteps} failed for deployment [${this.deploymentID}] : ${this.lastOperationResult.status}`);
+                break;
+
+            } else {
+                this.logger.info(`Lifecycle operation ${currentStep}/${totalSteps} result for deployment [${this.deploymentID}] : ${this.lastOperationResult.status}`);
+            }
+
+            currentStep++;
+
+        } while (this.queue.length > 0);
+
+        return this.lastOperationResult;
+    }
+}

--- a/modules/coordinator/src/coordinator/core/error/error-types.ts
+++ b/modules/coordinator/src/coordinator/core/error/error-types.ts
@@ -1,3 +1,4 @@
+import { DeploymentAttributes } from "@coordinator/core/domain";
 import { OAuthProviderType } from "@coordinator/core/service/oauth";
 
 /**
@@ -47,6 +48,26 @@ export class LockedDeploymentError extends GenericError {
 
     constructor(deploymentID: string) {
         super(`Deployment ${deploymentID} is locked`);
+    }
+}
+
+/**
+ * Error to be thrown when a deployment validation fails.
+ */
+export class DeploymentValidationError extends GenericError {
+
+    constructor(attributes: DeploymentAttributes, message: string) {
+        super(`Requested lifecycle operation for deployment ${attributes.deployment} with attributes [roll=${attributes.roll}; instance=${attributes.instance}] is not supported: ${message}`);
+    }
+}
+
+/**
+ * Error to be thrown when the multi-instance configuration to be created is invalid.
+ */
+export class InvalidMultiInstanceConfigurationError extends GenericError {
+
+    constructor(message: string) {
+        super(message);
     }
 }
 

--- a/modules/coordinator/src/coordinator/core/service/deployment-definition-service.ts
+++ b/modules/coordinator/src/coordinator/core/service/deployment-definition-service.ts
@@ -9,6 +9,10 @@ import { OAuthDescriptor } from "@coordinator/core/domain/oauth";
 import { checksum, DeploymentDefinition } from "@coordinator/core/domain/storage";
 import { LockedDeploymentError, UnknownDeploymentError } from "@coordinator/core/error/error-types";
 import {
+    multiInstanceConfigValidator,
+    MultiInstanceConfigValidator
+} from "@coordinator/core/service/instances/multi-instance-config-validator";
+import {
     oAuthRegistrationHandler,
     OAuthRegistrationHandler
 } from "@coordinator/core/service/oauth/oauth-registration-handler";
@@ -25,10 +29,13 @@ export class DeploymentDefinitionService {
 
     private readonly deploymentDefinitionDAO: DeploymentDefinitionDAO;
     private readonly oAuthRegistrationHandler: OAuthRegistrationHandler;
+    private readonly multiInstanceConfigValidator: MultiInstanceConfigValidator;
 
-    constructor(deploymentDefinitionDAO: DeploymentDefinitionDAO, oAuthRegistrationHandler: OAuthRegistrationHandler) {
+    constructor(deploymentDefinitionDAO: DeploymentDefinitionDAO, oAuthRegistrationHandler: OAuthRegistrationHandler,
+                multiInstanceConfigValidator: MultiInstanceConfigValidator) {
         this.deploymentDefinitionDAO = deploymentDefinitionDAO;
         this.oAuthRegistrationHandler = oAuthRegistrationHandler;
+        this.multiInstanceConfigValidator = multiInstanceConfigValidator;
     }
 
     /**
@@ -75,6 +82,8 @@ export class DeploymentDefinitionService {
      */
     public async saveDefinition(deployment: Deployment, lockDefinition: boolean): Promise<boolean> {
 
+        this.multiInstanceConfigValidator.validateDeploymentDefinition(deployment);
+
         const storedDefinition = await this.deploymentDefinitionDAO.findOne(deployment.id);
         if (!(await this.shouldSave(storedDefinition, deployment))) {
             this.logger.debug(`Definition ${deployment.id} already exists, skipping`);
@@ -108,11 +117,13 @@ export class DeploymentDefinitionService {
      */
     public async importDefinition(deployment: Deployment): Promise<boolean> {
 
-        await this.setLock(deployment.id, false);
-        const saveResult = await this.saveDefinition(deployment, true);
-        await this.setLock(deployment.id, true);
+        try {
+            await this.setLock(deployment.id, false);
+            return await this.saveDefinition(deployment, true);
 
-        return saveResult;
+        } finally {
+            await this.setLock(deployment.id, true);
+        }
     }
 
     /**
@@ -178,4 +189,4 @@ export class DeploymentDefinitionService {
 }
 
 export const deploymentDefinitionService =
-    new DeploymentDefinitionService(deploymentDefinitionDAO, oAuthRegistrationHandler);
+    new DeploymentDefinitionService(deploymentDefinitionDAO, oAuthRegistrationHandler, multiInstanceConfigValidator);

--- a/modules/coordinator/src/coordinator/core/service/deployment-facade.ts
+++ b/modules/coordinator/src/coordinator/core/service/deployment-facade.ts
@@ -1,35 +1,29 @@
 import { DeploymentAttributes } from "@coordinator/core/domain";
-import { UnknownDeploymentError } from "@coordinator/core/error/error-types";
-import {
-    deploymentDefinitionService,
-    DeploymentDefinitionService
-} from "@coordinator/core/service/deployment-definition-service";
+import { OperationQueue } from "@coordinator/core/domain/operation-queue";
 import { healthcheckProvider, HealthcheckProvider } from "@coordinator/core/service/healthcheck/healthcheck-provider";
 import { DeploymentInfoResponse } from "@coordinator/core/service/info";
 import { infoProvider, InfoProvider } from "@coordinator/core/service/info/info-provider";
-import { lifecycleService, LifecycleService } from "@coordinator/core/service/lifecycle-service";
-import { ExtendedDeployment } from "@coordinator/web/model/deployment";
-import { Deployment } from "@core-lib/platform/api/deployment";
 import {
-    DeploymentStatus,
-    DeploymentVersion,
-    DeploymentVersionType,
-    OperationResult
-} from "@core-lib/platform/api/lifecycle";
+    deploymentInstanceResolver,
+    DeploymentInstanceResolver
+} from "@coordinator/core/service/instances/deployment-instance-resolver";
+import { lifecycleService, LifecycleService } from "@coordinator/core/service/lifecycle-service";
+import { Deployment } from "@core-lib/platform/api/deployment";
+import { DeploymentVersion, DeploymentVersionType, OperationResult } from "@core-lib/platform/api/lifecycle";
 
 /**
  * Facade implementation combining and controlling the deployment operations.
  */
 export class DeploymentFacade {
 
-    private readonly deploymentDefinitionService: DeploymentDefinitionService;
+    private readonly deploymentInstanceResolver: DeploymentInstanceResolver;
     private readonly lifecycleService: LifecycleService;
     private readonly healthcheckProvider: HealthcheckProvider;
     private readonly infoProvider: InfoProvider;
 
-    constructor(deploymentDefinitionService: DeploymentDefinitionService, lifecycleService: LifecycleService,
+    constructor(deploymentInstanceResolver: DeploymentInstanceResolver, lifecycleService: LifecycleService,
                 healthcheckProvider: HealthcheckProvider, infoProvider: InfoProvider) {
-        this.deploymentDefinitionService = deploymentDefinitionService;
+        this.deploymentInstanceResolver = deploymentInstanceResolver;
         this.lifecycleService = lifecycleService;
         this.healthcheckProvider = healthcheckProvider;
         this.infoProvider = infoProvider;
@@ -42,7 +36,7 @@ export class DeploymentFacade {
      */
     public async info(deploymentAttributes: DeploymentAttributes): Promise<DeploymentInfoResponse> {
 
-        const deployment = await this.getDeployment(deploymentAttributes);
+        const deployment = await this.deploymentInstanceResolver.resolveSingleInstance(deploymentAttributes);
 
         return this.infoProvider.getAppInfo(deployment.id, deployment.info);
     }
@@ -54,10 +48,19 @@ export class DeploymentFacade {
      */
     public async deploy(deploymentAttributes: DeploymentAttributes): Promise<OperationResult> {
 
-        const deployment = await this.getDeployment(deploymentAttributes);
+        const deployments = await this.deploymentInstanceResolver.resolveInstances(deploymentAttributes);
         const deploymentVersion = this.getDeploymentVersion(deploymentAttributes);
 
-        return this.lifecycleService.deploy(deployment, deploymentVersion);
+        const queue = OperationQueue.create(deploymentAttributes.deployment);
+        deployments.forEach(deployment => {
+            queue.enqueue(() => this.lifecycleService.deploy(deployment, deploymentVersion));
+            if (deploymentAttributes.roll) {
+                queue.enqueue(() => this.lifecycleService.start(deployment));
+                queue.enqueue(() => this.mapHealthcheckResponse(deployment));
+            }
+        })
+
+        return queue.execute();
     }
 
     /**
@@ -75,10 +78,7 @@ export class DeploymentFacade {
      * @param deploymentAttributes DeploymentAttributes object containing the necessary parameters of selecting the relevant deployment
      */
     public async stop(deploymentAttributes: DeploymentAttributes): Promise<OperationResult> {
-
-        const deployment = await this.getDeployment(deploymentAttributes);
-
-        return this.lifecycleService.stop(deployment);
+        return this.executeWithHealthcheck(deploymentAttributes, deployment => this.lifecycleService.stop(deployment), false);
     }
 
     /**
@@ -88,16 +88,6 @@ export class DeploymentFacade {
      */
     public async restart(deploymentAttributes: DeploymentAttributes): Promise<OperationResult> {
         return this.executeWithHealthcheck(deploymentAttributes, deployment => this.lifecycleService.restart(deployment));
-    }
-
-    private async getDeployment(deploymentAttributes: DeploymentAttributes): Promise<Deployment> {
-
-        const deployment = await this.deploymentDefinitionService.getDeployment(deploymentAttributes.deployment, false) as ExtendedDeployment;
-        if (!deployment) {
-            throw new UnknownDeploymentError(deploymentAttributes.deployment);
-        }
-
-        return deployment;
     }
 
     private getDeploymentVersion(deploymentAttributes: DeploymentAttributes): DeploymentVersion {
@@ -110,15 +100,23 @@ export class DeploymentFacade {
         };
     }
 
+
+
     private async executeWithHealthcheck(deploymentAttributes: DeploymentAttributes,
-                                         operation: (deployment: Deployment) => Promise<OperationResult>): Promise<OperationResult> {
+                                         operation: (deployment: Deployment) => Promise<OperationResult>,
+                                         runHealthCheck: boolean = true): Promise<OperationResult> {
 
-        const deployment = await this.getDeployment(deploymentAttributes);
-        const operationResult = await operation(deployment);
+        const deployments = await this.deploymentInstanceResolver.resolveInstances(deploymentAttributes);
+        const queue = OperationQueue.create(deployments[0].id);
 
-        return operationResult.status === DeploymentStatus.UNKNOWN_STARTED
-            ? await this.mapHealthcheckResponse(deployment)
-            : operationResult;
+        deployments.forEach(deployment => {
+            queue.enqueue(() => operation(deployment));
+            if (runHealthCheck) {
+                queue.enqueue(() => this.mapHealthcheckResponse(deployment));
+            }
+        })
+
+        return await queue.execute();
     }
 
     private async mapHealthcheckResponse(deployment: Deployment): Promise<OperationResult> {
@@ -131,4 +129,4 @@ export class DeploymentFacade {
     }
 }
 
-export const deploymentFacade = new DeploymentFacade(deploymentDefinitionService, lifecycleService, healthcheckProvider, infoProvider);
+export const deploymentFacade = new DeploymentFacade(deploymentInstanceResolver, lifecycleService, healthcheckProvider, infoProvider);

--- a/modules/coordinator/src/coordinator/core/service/instances/deployment-instance-resolver.ts
+++ b/modules/coordinator/src/coordinator/core/service/instances/deployment-instance-resolver.ts
@@ -1,0 +1,214 @@
+import { DeploymentAttributes } from "@coordinator/core/domain";
+import { DeploymentValidationError } from "@coordinator/core/error/error-types";
+import {
+    deploymentDefinitionService,
+    DeploymentDefinitionService
+} from "@coordinator/core/service/deployment-definition-service";
+import {
+    MultiInstanceRequestValidator,
+    multiInstanceValidator
+} from "@coordinator/core/service/instances/multi-instance-request-validator";
+import { ExtendedDeployment } from "@coordinator/web/model/deployment";
+import {
+    Deployment,
+    DockerArguments,
+    InstanceNamingStrategy,
+    InstanceSpreadMode,
+    MultiInstanceDeployment
+} from "@core-lib/platform/api/deployment";
+
+/**
+ * Instance resolver implementation for multi-instance deployments.
+ */
+export class DeploymentInstanceResolver {
+
+    private readonly deploymentDefinitionService: DeploymentDefinitionService;
+    private readonly multiInstanceValidator: MultiInstanceRequestValidator;
+
+    constructor(deploymentDefinitionService: DeploymentDefinitionService, multiInstanceValidator: MultiInstanceRequestValidator) {
+        this.deploymentDefinitionService = deploymentDefinitionService;
+        this.multiInstanceValidator = multiInstanceValidator;
+    }
+
+    /**
+     * Strictly resolves one instance of a deployment, regardless if it's a single- or multi-instance deployment.
+     *
+     * @param deploymentAttributes deployment request attributes
+     */
+    public async resolveSingleInstance(deploymentAttributes: DeploymentAttributes): Promise<Deployment> {
+
+        const deployments = await this.resolveInstances(deploymentAttributes);
+
+        if (deployments.length !== 1) {
+            throw new DeploymentValidationError(deploymentAttributes, `Expected single resolved instance, got ${deployments.length}`);
+        }
+
+        return deployments[0];
+    }
+
+    /**
+     * Resolves all available instances of the given deployment. Returns immediately without any alignment on the deployment
+     * descriptor if it's a single-instance deployment, or splits and aligns the deployment descriptor if it's a multi-instance deployment.
+     *
+     * @param deploymentAttributes deployment request attributes
+     */
+    public async resolveInstances(deploymentAttributes: DeploymentAttributes): Promise<Deployment[]> {
+
+        const deployment = await this.deploymentDefinitionService.getDeployment(deploymentAttributes.deployment, false) as ExtendedDeployment;
+        this.multiInstanceValidator.validateLifecycleRequest(deploymentAttributes, deployment);
+        const multiInstanceConfig = this.getMultiInstanceConfiguration(deployment);
+
+        if (!multiInstanceConfig) {
+            return [deployment];
+
+        }
+        const suffixes = this.calculateSuffixes(multiInstanceConfig);
+
+        let alignedDeployments = suffixes
+            .filter(suffix => deploymentAttributes.roll || suffix === deploymentAttributes.instance)
+            .map(suffix => this.applySuffix(deployment, suffix))
+            .map(deployment => structuredClone(deployment))
+            .map((deployment, index) => this.alignDeployment(deployment, deploymentAttributes, index, suffixes))
+            .flatMap(deployment => this.alignTargetHostsForReplicationSpreading(deployment));
+
+        this.alignTargetHostsForOnePerHostSpreading(deployment, alignedDeployments);
+
+        return alignedDeployments;
+    }
+
+    private calculateSuffixes = (multiInstance: MultiInstanceDeployment) => {
+
+        const suffixes: string[] = [];
+
+        if (multiInstance.namingStrategy === InstanceNamingStrategy.CUSTOM_PREDEFINED) {
+            suffixes.push(...(multiInstance.definedNames ?? []));
+        } else {
+            for (let index = 0; index < multiInstance.instanceCount; index++) {
+                suffixes.push(index.toString());
+            }
+        }
+
+        return suffixes;
+    }
+
+    private alignTargetHostsForOnePerHostSpreading(deployment: Deployment, alignedDeployments: Deployment[]): void {
+
+        const multiInstance = this.getMultiInstanceConfiguration(deployment)!;
+
+        if (deployment.target.hosts.length > 1 && multiInstance.spreadMode === InstanceSpreadMode.ONE_PER_HOST) {
+            const targetHosts = deployment.target.hosts;
+            for (let index = 0; index < alignedDeployments.length; index++) {
+                alignedDeployments[index].target.hosts = [targetHosts[index]];
+            }
+        }
+    }
+
+    private alignTargetHostsForReplicationSpreading(deployment: Deployment): Deployment[] {
+
+        const multiInstance = this.getMultiInstanceConfiguration(deployment)!;
+
+        if (deployment.target.hosts.length === 1 || multiInstance.spreadMode === InstanceSpreadMode.ONE_PER_HOST) {
+            return [deployment];
+        }
+
+        return deployment.target.hosts
+            .map(host => ({
+                ...deployment,
+                target: {
+                    ...deployment.target,
+                    hosts: [host]
+                }
+            }))
+    }
+
+    private applySuffix(deployment: Deployment, suffix: string): Deployment {
+
+        return {
+            ...deployment,
+            execution: {
+                ...deployment.execution,
+                commandName: `${deployment.execution.commandName}-${suffix}`
+            }
+        };
+    }
+
+    private alignDeployment(deployment: Deployment, deploymentAttributes: DeploymentAttributes, index: number, suffixes: string[]): Deployment {
+
+        const multiInstance = this.getMultiInstanceConfiguration(deployment)!;
+
+        if (multiInstance.spreadMode === InstanceSpreadMode.ONE_PER_HOST) {
+            return deployment;
+        }
+
+        const actualIndex = deploymentAttributes.roll
+            ? index
+            : suffixes.findIndex(suffix => suffix === deploymentAttributes.instance);
+
+        this.alignEnvironment(deployment, actualIndex);
+        this.alignPorts(deployment, actualIndex);
+
+        return deployment;
+    }
+
+    private alignEnvironment(deployment: Deployment, index: number): void {
+        const multiInstance = this.getMultiInstanceConfiguration(deployment)!;
+        if (multiInstance.hostNetworkBasePort) {
+
+            if (!(deployment.execution.args as DockerArguments)?.environment) {
+                deployment.execution = {
+                    ...deployment.execution,
+                    args: {
+                        ...deployment.execution.args,
+                        environment: {}
+                    }
+                }
+            }
+
+            const instancePort = multiInstance.hostNetworkBasePort! + (index * multiInstance.portOffset);
+            (deployment.execution.args as DockerArguments)!.environment!.INSTANCE_PORT = instancePort.toString();
+            this.alignHealthCheckPort(deployment, multiInstance.hostNetworkBasePort.toString(), instancePort.toString());
+        }
+    }
+
+    private alignPorts(deployment: Deployment, index: number): void {
+
+        const multiInstance = this.getMultiInstanceConfiguration(deployment)!;
+        if (!multiInstance.hostNetworkBasePort) {
+
+            const remappedPorts: Record<string, string> = {};
+            const ports = (deployment.execution.args as DockerArguments)?.ports ?? {};
+            Object.keys(ports).forEach(port => {
+
+                const originalPort = parseInt(port);
+                const targetPort = ports[port];
+                const mappedPort = originalPort + (index * multiInstance.portOffset);
+                remappedPorts[mappedPort.toString()] = targetPort;
+                this.alignHealthCheckPort(deployment, port, mappedPort.toString());
+            });
+
+            (deployment.execution.args as DockerArguments)!.ports = remappedPorts;
+        }
+    }
+
+    private alignHealthCheckPort(deployment: Deployment, predefinedPort: string, alignedPort: string): void {
+
+        if (!deployment.healthcheck.enabled || predefinedPort === alignedPort) {
+            return;
+        }
+
+        if (!deployment.healthcheck.endpoint.includes(predefinedPort)) {
+            return;
+        }
+
+        deployment.healthcheck.endpoint = deployment.healthcheck.endpoint.replace(predefinedPort, alignedPort);
+    }
+
+    private getMultiInstanceConfiguration(deployment: Deployment): MultiInstanceDeployment | undefined {
+
+        return deployment.target.multiInstance?.enabled
+            ? deployment.target.multiInstance as MultiInstanceDeployment
+            : undefined;
+    }
+}
+
+export const deploymentInstanceResolver = new DeploymentInstanceResolver(deploymentDefinitionService, multiInstanceValidator);

--- a/modules/coordinator/src/coordinator/core/service/instances/multi-instance-config-validator.ts
+++ b/modules/coordinator/src/coordinator/core/service/instances/multi-instance-config-validator.ts
@@ -1,0 +1,110 @@
+import { InvalidMultiInstanceConfigurationError } from "@coordinator/core/error/error-types";
+import {
+    Deployment,
+    DockerArguments,
+    InstanceNamingStrategy,
+    InstanceSpreadMode,
+    MultiInstanceDeployment,
+    SourceType
+} from "@core-lib/platform/api/deployment";
+
+/**
+ * Configuration request validator for multi-instance deployments.
+ */
+export class MultiInstanceConfigValidator {
+
+    /**
+     * Verifies the following requirements for multi-instance deployments:
+     * - Source type is Docker
+     * - Instance count is at least 2
+     * - Defined names are unique (if custom-predefined naming strategy is used)
+     * - Defined names are not defined for incremental naming strategy
+     * - Host network base port is defined for host network mode
+     * - Host network base port is not defined for bridged network mode
+     * - Port offset is defined for host replication spread mode
+     * - Instance count matches the number of hosts for one-per-host spread mode.
+     *
+     * Skips verification if multi-instance is not enabled for the deployment.
+     *
+     * @param deployment deployment definition to check multi-instance configuration
+     */
+    public validateDeploymentDefinition(deployment: Deployment): void {
+
+        if (!deployment.target.multiInstance?.enabled) {
+            this.verifySingleHost(deployment);
+            return;
+        }
+
+        const multiInstanceConfig = this.getMultiInstanceConfiguration(deployment);
+
+        this.verifySourceType(deployment);
+        this.verifyInstanceCount(multiInstanceConfig);
+        this.verifyDefinesNames(multiInstanceConfig);
+        this.verifyPortConfiguration(multiInstanceConfig, deployment);
+    }
+
+    private verifySingleHost(deployment: Deployment): void {
+
+        this.verifyConfig(() => deployment.target.hosts.length > 1,
+            "Multi-instance deployment must be enabled for multi-host deployments");
+    }
+
+    private verifySourceType(deployment: Deployment): void {
+
+        this.verifyConfig(() => deployment.source.type !== SourceType.DOCKER,
+            "Multi-instance deployments are only supported for Docker deployments");
+    }
+
+    private verifyInstanceCount(multiInstanceConfig: MultiInstanceDeployment): void {
+
+        this.verifyConfig(() => multiInstanceConfig.instanceCount < 2,
+            "Instance count must be at least 2 for multi-instance deployments");
+    }
+
+    private verifyDefinesNames(multiInstanceConfig: MultiInstanceDeployment): void {
+
+        if (multiInstanceConfig.namingStrategy === InstanceNamingStrategy.CUSTOM_PREDEFINED) {
+
+            this.verifyConfig(() => !multiInstanceConfig.definedNames || multiInstanceConfig.definedNames.length !== multiInstanceConfig.instanceCount,
+                "Number of custom predefined instance names must match the instance count");
+
+            this.verifyConfig(() => new Set(multiInstanceConfig.definedNames).size !== multiInstanceConfig.definedNames!.length,
+                "Custom predefined instance names must be unique");
+
+        } else {
+
+            this.verifyConfig(() => (multiInstanceConfig.definedNames?.length ?? 0) !== 0,
+                "Defined names must not be defined for incremental naming strategy");
+        }
+    }
+
+    private verifyPortConfiguration(multiInstanceConfig: MultiInstanceDeployment, deployment: Deployment): void {
+
+        const dockerArguments = deployment.execution.args as DockerArguments;
+
+        this.verifyConfig(() => dockerArguments.networkMode === "host" && !multiInstanceConfig.hostNetworkBasePort,
+            "Host network base port must be defined for host network mode");
+
+        this.verifyConfig(() => dockerArguments.networkMode !== "host" && multiInstanceConfig.hostNetworkBasePort !== undefined,
+            "Host network base port must not be defined for bridged network mode");
+
+        this.verifyConfig(() => multiInstanceConfig.spreadMode === InstanceSpreadMode.REPLICATE && !multiInstanceConfig.portOffset,
+            "Port offset must be defined for host replication spread mode");
+
+        this.verifyConfig(() => multiInstanceConfig.spreadMode === InstanceSpreadMode.ONE_PER_HOST && multiInstanceConfig.instanceCount !== deployment.target.hosts.length,
+            "Instance count must match the number of hosts for one-per-host spread mode");
+    }
+
+    private verifyConfig(invalidOnCondition: () => boolean, message: string): void {
+
+        if (invalidOnCondition()) {
+            throw new InvalidMultiInstanceConfigurationError(message);
+        }
+    }
+
+    private getMultiInstanceConfiguration(deployment: Deployment): MultiInstanceDeployment {
+        return deployment.target.multiInstance as MultiInstanceDeployment;
+    }
+}
+
+export const multiInstanceConfigValidator = new MultiInstanceConfigValidator();

--- a/modules/coordinator/src/coordinator/core/service/instances/multi-instance-request-validator.ts
+++ b/modules/coordinator/src/coordinator/core/service/instances/multi-instance-request-validator.ts
@@ -1,0 +1,96 @@
+import { DeploymentAttributes } from "@coordinator/core/domain";
+import { DeploymentValidationError } from "@coordinator/core/error/error-types";
+import { Deployment, InstanceNamingStrategy, MultiInstanceDeployment } from "@core-lib/platform/api/deployment";
+
+/**
+ * Lifecycle request validator for multi-instance deployments.
+ */
+export class MultiInstanceRequestValidator {
+
+    /**
+     * Validates the given lifecycle request for multi-instance deployments.
+     *
+     * @param deploymentAttributes deployment attributes to be validated
+     * @param deployment deployment descriptor containing the multi-instance configuration to validate against
+     * @throws DeploymentValidationError if the request is invalid
+     */
+    public validateLifecycleRequest(deploymentAttributes: DeploymentAttributes, deployment: Deployment): void {
+
+        this.invalidRequestPredicates().forEach(predicate => {
+            const [invalid, message] = predicate(deploymentAttributes, deployment);
+            if (invalid) {
+                throw new DeploymentValidationError(deploymentAttributes, message);
+            }
+        })
+    }
+
+    private invalidRequestPredicates(): ((deploymentAttributes: DeploymentAttributes, deployment: Deployment) => [boolean, string])[] {
+
+        return [
+            (deploymentAttributes, deployment) => [
+                this.isMultiInstanceEnabled(deployment) && !this.isMultiInstanceDeploymentRequested(deploymentAttributes),
+                "Multi-instance deployment attribute is expected for this deployment"
+            ],
+            (deploymentAttributes, deployment) => [
+                !this.isMultiInstanceEnabled(deployment) && this.isMultiInstanceDeploymentRequested(deploymentAttributes),
+                "Multi-instance deployment is not enabled for this deployment"
+            ],
+            (deploymentAttributes, deployment) => [
+                !(this.shouldSkipCheck(deployment) || !deploymentAttributes.roll || deploymentAttributes.instance === undefined),
+                "Rolling all instances and an exact instance at once is not possible"
+            ],
+            (deploymentAttributes, deployment) => [
+                !(this.shouldSkipCheck(deployment) || deploymentAttributes.roll || this.isValidSuffixRequested(deployment, deploymentAttributes)),
+                "Requested instance suffix is not valid for this deployment"
+            ]
+        ];
+    }
+
+    private isMultiInstanceDeploymentRequested(deploymentAttributes: DeploymentAttributes): boolean {
+        return deploymentAttributes.roll || deploymentAttributes.instance !== undefined;
+    }
+
+    private isMultiInstanceEnabled(deployment: Deployment): boolean {
+        return deployment.target.multiInstance?.enabled ?? false;
+    }
+
+    private shouldSkipCheck(deployment: Deployment): boolean {
+        return !this.isMultiInstanceEnabled(deployment);
+    }
+
+    private isValidSuffixRequested(deployment: Deployment, deploymentAttributes: DeploymentAttributes): boolean {
+
+        return this.isMultiInstanceEnabled(deployment) && (
+            this.isIncrementalSuffixRequested(deploymentAttributes, deployment)
+            || this.isPredefinedSuffixRequested(deploymentAttributes, deployment)
+        );
+    }
+
+    private isIncrementalSuffixRequested(deploymentAttributes: DeploymentAttributes, deployment: Deployment): boolean {
+
+        const requestedSuffix = this.extractSuffix(deploymentAttributes);
+        const multiInstanceConfiguration = this.getMultiInstanceConfiguration(deployment);
+
+        return multiInstanceConfiguration.namingStrategy === InstanceNamingStrategy.INCREMENTAL_SUFFIX
+            && /^[0-9]+$/.test(requestedSuffix)
+            && (requestedSuffix === "0" || parseInt(requestedSuffix) < multiInstanceConfiguration.instanceCount);
+    }
+
+    private isPredefinedSuffixRequested(deploymentAttributes: DeploymentAttributes, deployment: Deployment): boolean {
+
+        const multiInstanceConfig = this.getMultiInstanceConfiguration(deployment);
+
+        return multiInstanceConfig.namingStrategy === InstanceNamingStrategy.CUSTOM_PREDEFINED
+            && (multiInstanceConfig.definedNames?.includes(this.extractSuffix(deploymentAttributes)) ?? false);
+    }
+
+    private extractSuffix(deploymentAttributes: DeploymentAttributes): string {
+        return deploymentAttributes.instance ?? "";
+    }
+
+    private getMultiInstanceConfiguration(deployment: Deployment): MultiInstanceDeployment {
+        return deployment.target.multiInstance as MultiInstanceDeployment;
+    }
+}
+
+export const multiInstanceValidator = new MultiInstanceRequestValidator();

--- a/modules/coordinator/src/coordinator/core/service/lifecycle-service.ts
+++ b/modules/coordinator/src/coordinator/core/service/lifecycle-service.ts
@@ -9,6 +9,7 @@ import { Deployment } from "@core-lib/platform/api/deployment";
 import { DeploymentVersion, OperationResult } from "@core-lib/platform/api/lifecycle";
 import { LifecycleOperation } from "@core-lib/platform/api/lifecycle/lifecycle-operation";
 import { Lifecycle, LifecycleCommand, MessageType, SocketMessage } from "@core-lib/platform/api/socket";
+import LoggerFactory from "@core-lib/platform/logging";
 import { hrtime } from "node:process";
 
 /**
@@ -17,6 +18,8 @@ import { hrtime } from "node:process";
  * a lifecycle request to the specific agent. Finally, each method awaits for the agent's response and returns it.
  */
 export class LifecycleService implements LifecycleOperation {
+
+    private readonly logger = LoggerFactory.getLogger(LifecycleService);
 
     private readonly agentRegistry: AgentRegistry;
     private readonly lifecycleOperationRegistry: LifecycleOperationRegistry;
@@ -49,6 +52,7 @@ export class LifecycleService implements LifecycleOperation {
         const agent = this.agentRegistry.getFirstAvailable(deployment);
         const message: SocketMessage<Lifecycle> = this.createLifecycleMessage(command, deployment, version);
         const secrets = await this.secretDAO.findAll();
+        this.logger.info(`Submitting lifecycle operation ${command} for deployment ${deployment.id} with messageID ${message.messageID}`);
         sendMessage(agent.socket, message, secrets);
 
         return await this.lifecycleOperationRegistry.operationStarted(message.messageID);

--- a/modules/coordinator/src/coordinator/core/service/oauth/lags/lags-access-token-registry.ts
+++ b/modules/coordinator/src/coordinator/core/service/oauth/lags/lags-access-token-registry.ts
@@ -56,7 +56,7 @@ export class LAGSAccessTokenRegistry {
             const tokenResponse = (await this.requestToken(provider)).data;
             this.tokenCache.set(provider.name, {
                 accessToken: tokenResponse.access_token,
-                expiresAt: new Date().getTime() + (tokenResponse.expires_in * 1000),
+                expiresAt: new Date().getTime() + (tokenResponse.expires_in * 1000)
             })
         }
 

--- a/modules/coordinator/src/coordinator/core/service/registry/agent-registry.ts
+++ b/modules/coordinator/src/coordinator/core/service/registry/agent-registry.ts
@@ -118,9 +118,8 @@ export class AgentRegistry {
     }
 
     /**
-     * Returns the (first available) assigned agent for the given deployment. If more than one agent is assigned to the
-     * deployment, returns the first matching one. This method should be deprecated, once support for multi-instance
-     * deployments is implemented.
+     * Returns the assigned agent for the given deployment. Since multi-instance support, deployment definition alignment
+     * makes sure that there's always only one target host in the effective descriptor.
      *
      * @param deployment Deployment configuration containing the name and type of the assigned agent
      */

--- a/modules/coordinator/src/coordinator/core/socket/lifecycle-operation-registry.ts
+++ b/modules/coordinator/src/coordinator/core/socket/lifecycle-operation-registry.ts
@@ -101,6 +101,7 @@ export class LifecycleOperationRegistry {
      * @param operationResult OperationResult message coming from the agent
      */
     public operationFinished(messageID: string, operationResult: OperationResult): void {
+        this.logger.info(`Operation ${messageID} completed with result: ${operationResult.status}`);
         this.handleCommandResult(messageID, activeCommand => activeCommand.finished(operationResult));
     }
 

--- a/modules/coordinator/src/coordinator/web/controller/lifecycle-controller.ts
+++ b/modules/coordinator/src/coordinator/web/controller/lifecycle-controller.ts
@@ -10,7 +10,7 @@ import { OperationResult } from "@core-lib/platform/api/lifecycle";
 import LoggerFactory from "@core-lib/platform/logging";
 
 /**
- * Controller implementation to handle lifecycle of registered applications.
+ * Controller implementation to handle the lifecycle of the registered applications.
  */
 export class LifecycleController implements Controller {
 
@@ -42,7 +42,7 @@ export class LifecycleController implements Controller {
 
     /**
      * PUT /lifecycle/:app/deploy[/:version]
-     * Prepares given application for execution.
+     * Prepares the given application for execution.
      * Omitting version path parameter instructs Domino to select the latest available version.
      *
      * @param lifecycleRequest VersionedLifecycleRequest object containing information about the target deployment

--- a/modules/coordinator/src/coordinator/web/conversion/index.ts
+++ b/modules/coordinator/src/coordinator/web/conversion/index.ts
@@ -14,7 +14,9 @@ export const lifecycleRequestConverter = (lifecycleRequest: LifecycleRequest | V
         deployment: lifecycleRequest.deployment,
         version: lifecycleRequest instanceof VersionedLifecycleRequest
             ? lifecycleRequest.version
-            : undefined
+            : undefined,
+        roll: lifecycleRequest.roll,
+        instance: lifecycleRequest.instance
     }
 }
 

--- a/modules/coordinator/src/coordinator/web/model/lifecycle.ts
+++ b/modules/coordinator/src/coordinator/web/model/lifecycle.ts
@@ -1,6 +1,6 @@
 import { validIDMatcher, validVersionMatcher } from "@core-lib/platform/api/deployment";
 import { DeploymentStatus } from "@core-lib/platform/api/lifecycle";
-import { IsOptional, Matches } from "class-validator";
+import { IsEmpty, IsOptional, Matches, ValidateIf } from "class-validator";
 import { Request } from "express";
 import { hrtime } from "node:process";
 
@@ -13,14 +13,22 @@ export class LifecycleRequest {
     readonly deployment: string;
     readonly callStartTime: bigint;
 
+    readonly roll: boolean;
+
+    @ValidateIf(request => request.roll)
+    @IsEmpty()
+    readonly instance?: string;
+
     constructor(request: Request) {
         this.deployment = request.params.deployment;
         this.callStartTime = hrtime.bigint();
+        this.roll = request.query?.roll === "true";
+        this.instance = request.query?.instance as string;
     }
 }
 
 /**
- * Lifecycle request model with optional version field (for deployment requests).
+ * Lifecycle request model with an optional version field (for deployment requests).
  */
 export class VersionedLifecycleRequest extends LifecycleRequest {
 

--- a/modules/coordinator/src/coordinator/web/utility/middleware.ts
+++ b/modules/coordinator/src/coordinator/web/utility/middleware.ts
@@ -2,6 +2,7 @@ import {
     ConflictingSecretError,
     DirectAuthError,
     InvalidImportedDeploymentError,
+    InvalidMultiInstanceConfigurationError,
     LockedDeploymentError,
     MissingOAuthApplicationError,
     MissingOAuthEntityError,
@@ -29,6 +30,7 @@ const logger = LoggerFactory.getLogger("ErrorHandlerMiddleware");
 const errorStatusMap = new Map<string, HttpStatus>([
     [InvalidRequestError.name, HttpStatus.BAD_REQUEST],
     [InvalidImportedDeploymentError.name, HttpStatus.BAD_REQUEST],
+    [InvalidMultiInstanceConfigurationError.name, HttpStatus.BAD_REQUEST],
     [LockedDeploymentError.name, HttpStatus.CONFLICT],
     [UnknownDeploymentError.name, HttpStatus.NOT_FOUND],
     [UnauthorizedError.name, HttpStatus.FORBIDDEN],

--- a/modules/coordinator/tests/coordinator/core/config/deployment.testdata.ts
+++ b/modules/coordinator/tests/coordinator/core/config/deployment.testdata.ts
@@ -4,6 +4,8 @@ import {
     Deployment,
     DockerExecutionType,
     FilesystemExecutionType,
+    InstanceNamingStrategy,
+    InstanceSpreadMode,
     SourceType
 } from "@core-lib/platform/api/deployment";
 
@@ -45,7 +47,16 @@ export const dockerNoArgsDeployment: Deployment = {
     target: {
         hosts: [
             "localhost"
-        ]
+        ],
+        multiInstance: {
+            enabled: true,
+            instanceCount: 2,
+            spreadMode: InstanceSpreadMode.REPLICATE,
+            namingStrategy: InstanceNamingStrategy.INCREMENTAL_SUFFIX,
+            definedNames: [],
+            portOffset: 100,
+            hostNetworkBasePort: undefined
+        }
     },
     execution: {
         via: DockerExecutionType.STANDARD,
@@ -81,6 +92,12 @@ domino:
       target:
         hosts:
           - localhost
+        multi-instance:
+          enabled: true
+          instance-count: 2
+          spread-mode: replicate
+          naming-strategy: incremental-suffix
+          port-offset: +100
       execution:
         command-name: app_docker_no_args
         via: STANDARD
@@ -104,7 +121,19 @@ export const dockerAllArgsDeployment: Deployment = {
     target: {
         hosts: [
             "localhost"
-        ]
+        ],
+        multiInstance: {
+            enabled: true,
+            instanceCount: 2,
+            spreadMode: InstanceSpreadMode.REPLICATE,
+            namingStrategy: InstanceNamingStrategy.CUSTOM_PREDEFINED,
+            definedNames: [
+                "primary",
+                "standby"
+            ],
+            portOffset: 200,
+            hostNetworkBasePort: 9000
+        }
     },
     execution: {
         via: DockerExecutionType.STANDARD,
@@ -161,6 +190,16 @@ domino:
       target:
         hosts:
           - localhost
+        multi-instance:
+          enabled: true
+          instance-count: 2
+          naming-strategy: custom-predefined
+          defined-names:
+            - primary
+            - standby
+          spread-mode: replicate
+          port-offset: +200
+          host-network-base-port: 9000
       execution:
         command-name: app_docker_all_args
         via: STANDARD
@@ -209,8 +248,23 @@ export const dockerCustomDeployment: Deployment = {
     },
     target: {
         hosts: [
-            "localhost"
-        ]
+            "localhost",
+            "host2",
+            "host3"
+        ],
+        multiInstance: {
+            enabled: true,
+            instanceCount: 3,
+            spreadMode: InstanceSpreadMode.ONE_PER_HOST,
+            namingStrategy: InstanceNamingStrategy.CUSTOM_PREDEFINED,
+            definedNames: [
+                "instance-1",
+                "instance-2",
+                "instance-3"
+            ],
+            portOffset: 0,
+            hostNetworkBasePort: undefined
+        }
     },
     execution: {
         via: DockerExecutionType.STANDARD,
@@ -246,6 +300,18 @@ domino:
       target:
         hosts:
           - localhost
+          - host2
+          - host3
+        multi-instance:
+          enabled: true
+          instance-count: 3
+          naming-strategy: custom-predefined
+          defined-names:
+            - instance-1
+            - instance-2
+            - instance-3
+          spread-mode: one-per-host
+          port-offset: 0
       execution:
         command-name: app_docker_custom
         via: STANDARD
@@ -270,7 +336,10 @@ export const filesystemServiceDeployment: Deployment = {
     target: {
         hosts: [
             "localhost"
-        ]
+        ],
+        multiInstance: {
+            enabled: false
+        }
     },
     execution: {
         via: FilesystemExecutionType.SERVICE,
@@ -336,7 +405,10 @@ export const filesystemExecutableDeployment: Deployment = {
     target: {
         hosts: [
             "localhost"
-        ]
+        ],
+        multiInstance: {
+            enabled: false
+        }
     },
     execution: {
         via: FilesystemExecutionType.EXECUTABLE,
@@ -392,7 +464,10 @@ export const filesystemRuntimeDeployment: Deployment = {
     target: {
         hosts: [
             "localhost"
-        ]
+        ],
+        multiInstance: {
+            enabled: false
+        }
     },
     execution: {
         via: FilesystemExecutionType.RUNTIME,

--- a/modules/coordinator/tests/coordinator/core/core.testdata.ts
+++ b/modules/coordinator/tests/coordinator/core/core.testdata.ts
@@ -21,12 +21,23 @@ import { dockerAllArgsDeployment, dockerAllArgsDeploymentDefinition } from "@tes
 
 export const deploymentAttributes: DeploymentAttributes = {
     deployment: "domino",
-    version: undefined
+    version: undefined,
+    roll: false,
+    instance: undefined
+}
+
+export const rollingDeploymentAttributes: DeploymentAttributes = {
+    deployment: "domino",
+    version: undefined,
+    roll: true,
+    instance: undefined
 }
 
 export const versionedDeploymentAttributes: DeploymentAttributes = {
     deployment: "domino",
-    version: "1.2.3"
+    version: "1.2.3",
+    roll: false,
+    instance: undefined
 }
 
 export const deploymentInfoResponse: DeploymentInfoResponse = {
@@ -139,6 +150,26 @@ export const deployment: Deployment = {
 
 export const extendedDeployment: ExtendedDeployment = {
     ...deployment,
+    metadata: {
+        locked: false,
+        createdAt: new Date(),
+        updatedAt: new Date()
+    }
+}
+
+export const extendedDeploymentPrimary: ExtendedDeployment = {
+    ...deployment,
+    id: "domino-primary",
+    metadata: {
+        locked: false,
+        createdAt: new Date(),
+        updatedAt: new Date()
+    }
+}
+
+export const extendedDeploymentStandby: ExtendedDeployment = {
+    ...deployment,
+    id: "domino-standby",
     metadata: {
         locked: false,
         createdAt: new Date(),

--- a/modules/coordinator/tests/coordinator/core/service/deployment-definition-service.test.ts
+++ b/modules/coordinator/tests/coordinator/core/service/deployment-definition-service.test.ts
@@ -3,6 +3,7 @@ import { DeploymentDefinitionDAO } from "@coordinator/core/dao/deployment-defini
 import { DeploymentDefinition } from "@coordinator/core/domain/storage";
 import { LockedDeploymentError, UnknownDeploymentError } from "@coordinator/core/error/error-types";
 import { DeploymentDefinitionService } from "@coordinator/core/service/deployment-definition-service";
+import { MultiInstanceConfigValidator } from "@coordinator/core/service/instances/multi-instance-config-validator";
 import { OAuthRegistrationHandler } from "@coordinator/core/service/oauth/oauth-registration-handler";
 import { DeploymentExport } from "@coordinator/web/model/deployment";
 import { pagedDeployments, pagedDeploymentSummaries } from "@testdata/core";
@@ -24,14 +25,16 @@ describe("Unit tests for DeploymentDefinitionService", () => {
     let deploymentDefinitionDAOMock: SinonStubbedInstance<DeploymentDefinitionDAO>;
     let oAuthRegistrationHandlerMock: SinonStubbedInstance<OAuthRegistrationHandler>;
     let storedDefinitionMock: SinonStubbedInstance<DeploymentDefinition>;
+    let multiInstanceConfigValidator: SinonStubbedInstance<MultiInstanceConfigValidator>;
     let deploymentDefinitionService: DeploymentDefinitionService;
 
     beforeEach(() => {
         deploymentDefinitionDAOMock = sinon.createStubInstance(DeploymentDefinitionDAO);
         oAuthRegistrationHandlerMock = sinon.createStubInstance(OAuthRegistrationHandler);
         storedDefinitionMock = sinon.createStubInstance(DeploymentDefinition);
+        multiInstanceConfigValidator = sinon.createStubInstance(MultiInstanceConfigValidator);
 
-        deploymentDefinitionService = new DeploymentDefinitionService(deploymentDefinitionDAOMock, oAuthRegistrationHandlerMock);
+        deploymentDefinitionService = new DeploymentDefinitionService(deploymentDefinitionDAOMock, oAuthRegistrationHandlerMock, multiInstanceConfigValidator);
     });
 
     describe("Test scenarios for #getDeploymentsPaged", () => {

--- a/modules/coordinator/tests/coordinator/core/service/deployment-facade.test.ts
+++ b/modules/coordinator/tests/coordinator/core/service/deployment-facade.test.ts
@@ -1,8 +1,9 @@
+import { OperationQueue } from "@coordinator/core/domain/operation-queue";
 import { UnknownDeploymentError } from "@coordinator/core/error/error-types";
-import { DeploymentDefinitionService } from "@coordinator/core/service/deployment-definition-service";
 import { DeploymentFacade } from "@coordinator/core/service/deployment-facade";
 import { HealthcheckProvider } from "@coordinator/core/service/healthcheck/healthcheck-provider";
 import { InfoProvider } from "@coordinator/core/service/info/info-provider";
+import { DeploymentInstanceResolver } from "@coordinator/core/service/instances/deployment-instance-resolver";
 import { LifecycleService } from "@coordinator/core/service/lifecycle-service";
 import { DeploymentStatus, DeploymentVersion, DeploymentVersionType } from "@core-lib/platform/api/lifecycle";
 import {
@@ -10,6 +11,9 @@ import {
     deploymentInfoResponse,
     deployOperationResult,
     extendedDeployment,
+    extendedDeploymentPrimary,
+    extendedDeploymentStandby,
+    rollingDeploymentAttributes,
     startFailureOperationResult,
     startOperationResult,
     stopOperationResult,
@@ -21,18 +25,18 @@ import sinon, { SinonStubbedInstance } from "sinon";
 
 describe("Unit tests for DeploymentFacade", () => {
 
-    let deploymentDefinitionServiceMock: SinonStubbedInstance<DeploymentDefinitionService>;
+    let deploymentInstanceResolver: SinonStubbedInstance<DeploymentInstanceResolver>;
     let lifecycleServiceMock: SinonStubbedInstance<LifecycleService>;
     let healthcheckProviderMock: SinonStubbedInstance<HealthcheckProvider>;
     let infoProviderMock: SinonStubbedInstance<InfoProvider>;
     let deploymentFacade: DeploymentFacade;
 
     beforeEach(() => {
-        deploymentDefinitionServiceMock = sinon.createStubInstance(DeploymentDefinitionService);
+        deploymentInstanceResolver = sinon.createStubInstance(DeploymentInstanceResolver);
         lifecycleServiceMock = sinon.createStubInstance(LifecycleService);
         healthcheckProviderMock = sinon.createStubInstance(HealthcheckProvider);
         infoProviderMock = sinon.createStubInstance(InfoProvider);
-        deploymentFacade = new DeploymentFacade(deploymentDefinitionServiceMock, lifecycleServiceMock, healthcheckProviderMock, infoProviderMock);
+        deploymentFacade = new DeploymentFacade(deploymentInstanceResolver, lifecycleServiceMock, healthcheckProviderMock, infoProviderMock);
     });
 
     describe("Test scenarios for #info", () => {
@@ -40,7 +44,7 @@ describe("Unit tests for DeploymentFacade", () => {
         it("should return deployment info", async () => {
 
             // given
-            deploymentDefinitionServiceMock.getDeployment.withArgs(deploymentAttributes.deployment)
+            deploymentInstanceResolver.resolveSingleInstance.withArgs(deploymentAttributes)
                 .resolves(extendedDeployment);
             infoProviderMock.getAppInfo.withArgs(extendedDeployment.id, extendedDeployment.info)
                 .resolves(deploymentInfoResponse);
@@ -63,8 +67,8 @@ describe("Unit tests for DeploymentFacade", () => {
                 versionType: DeploymentVersionType.EXACT
             }
 
-            deploymentDefinitionServiceMock.getDeployment.withArgs(versionedDeploymentAttributes.deployment)
-                .resolves(extendedDeployment);
+            deploymentInstanceResolver.resolveInstances.withArgs(versionedDeploymentAttributes)
+                .resolves([extendedDeployment]);
             lifecycleServiceMock.deploy.withArgs(extendedDeployment, expectedVersion)
                 .resolves(versionedDeployOperationResult);
 
@@ -83,8 +87,8 @@ describe("Unit tests for DeploymentFacade", () => {
                 versionType: DeploymentVersionType.LATEST
             }
 
-            deploymentDefinitionServiceMock.getDeployment.withArgs(deploymentAttributes.deployment)
-                .resolves(extendedDeployment);
+            deploymentInstanceResolver.resolveInstances.withArgs(deploymentAttributes)
+                .resolves([extendedDeployment]);
             lifecycleServiceMock.deploy.withArgs(extendedDeployment, expectedVersion)
                 .resolves(deployOperationResult);
 
@@ -95,11 +99,68 @@ describe("Unit tests for DeploymentFacade", () => {
             expect(result).toStrictEqual(deployOperationResult);
         });
 
+        it("should request rolling deployment with latest version", async () => {
+
+            // given
+            const expectedVersion: DeploymentVersion = {
+                version: undefined,
+                versionType: DeploymentVersionType.LATEST
+            }
+
+            deploymentInstanceResolver.resolveInstances.withArgs(rollingDeploymentAttributes)
+                .resolves([extendedDeploymentPrimary, extendedDeploymentStandby]);
+
+            lifecycleServiceMock.deploy.withArgs(extendedDeploymentPrimary, expectedVersion)
+                .resolves(deployOperationResult);
+            lifecycleServiceMock.start.withArgs(extendedDeploymentPrimary)
+                .resolves(unknownStartedOperationResult);
+            healthcheckProviderMock.executeHealthcheck
+                .withArgs(extendedDeploymentPrimary.id, extendedDeploymentPrimary.healthcheck)
+                .resolves(startOperationResult.status);
+
+            lifecycleServiceMock.deploy.withArgs(extendedDeploymentStandby, expectedVersion)
+                .resolves(deployOperationResult);
+            lifecycleServiceMock.start.withArgs(extendedDeploymentStandby)
+                .resolves(unknownStartedOperationResult);
+            healthcheckProviderMock.executeHealthcheck
+                .withArgs(extendedDeploymentStandby.id, extendedDeploymentStandby.healthcheck)
+                .resolves(startOperationResult.status);
+
+            // when
+            const result = await deploymentFacade.deploy(rollingDeploymentAttributes);
+
+            // then
+            expect(result).toStrictEqual(startOperationResult);
+        });
+
+        it("should rolling deployment immediately stop on any error", async () => {
+
+            // given
+            const expectedVersion: DeploymentVersion = {
+                version: undefined,
+                versionType: DeploymentVersionType.LATEST
+            }
+
+            deploymentInstanceResolver.resolveInstances.withArgs(rollingDeploymentAttributes)
+                .resolves([extendedDeploymentPrimary, extendedDeploymentStandby]);
+
+            lifecycleServiceMock.deploy.withArgs(extendedDeploymentPrimary, expectedVersion)
+                .resolves(deployOperationResult);
+            lifecycleServiceMock.start.withArgs(extendedDeploymentPrimary)
+                .resolves(startFailureOperationResult);
+
+            // when
+            const result = await deploymentFacade.deploy(rollingDeploymentAttributes);
+
+            // then
+            expect(result).toStrictEqual(startFailureOperationResult);
+        });
+
         it("should throw error on requesting deployment of non-existing application", async () => {
 
             // given
-            deploymentDefinitionServiceMock.getDeployment.withArgs(deploymentAttributes.deployment)
-                .resolves(undefined);
+            deploymentInstanceResolver.resolveInstances.withArgs(deploymentAttributes)
+                .rejects(new UnknownDeploymentError("app"));
 
             // when
             const failingCall = () => deploymentFacade.deploy(deploymentAttributes);
@@ -114,8 +175,8 @@ describe("Unit tests for DeploymentFacade", () => {
         it("should execute operation and attempt healthcheck on UNKNOWN_STARTED status", async () => {
 
             // given
-            deploymentDefinitionServiceMock.getDeployment.withArgs(deploymentAttributes.deployment)
-                .resolves(extendedDeployment);
+            deploymentInstanceResolver.resolveInstances.withArgs(deploymentAttributes)
+                .resolves([extendedDeployment]);
             lifecycleServiceMock.start.withArgs(extendedDeployment)
                 .resolves(unknownStartedOperationResult);
             healthcheckProviderMock.executeHealthcheck.withArgs(extendedDeployment.id, extendedDeployment.healthcheck)
@@ -128,11 +189,34 @@ describe("Unit tests for DeploymentFacade", () => {
             expect(result).toStrictEqual(startOperationResult);
         });
 
+        it("should execute operation and attempt healthcheck on UNKNOWN_STARTED status for all instances", async () => {
+
+            // given
+            deploymentInstanceResolver.resolveInstances.withArgs(rollingDeploymentAttributes)
+                .resolves([extendedDeploymentPrimary, extendedDeploymentStandby]);
+
+            lifecycleServiceMock.start.withArgs(extendedDeploymentPrimary)
+                .resolves(unknownStartedOperationResult);
+            healthcheckProviderMock.executeHealthcheck.withArgs(extendedDeploymentPrimary.id, extendedDeploymentPrimary.healthcheck)
+                .resolves(DeploymentStatus.HEALTH_CHECK_OK);
+
+            lifecycleServiceMock.start.withArgs(extendedDeploymentStandby)
+                .resolves(unknownStartedOperationResult);
+            healthcheckProviderMock.executeHealthcheck.withArgs(extendedDeploymentStandby.id, extendedDeploymentStandby.healthcheck)
+                .resolves(DeploymentStatus.HEALTH_CHECK_OK);
+
+            // when
+            const result = await deploymentFacade.start(rollingDeploymentAttributes);
+
+            // then
+            expect(result).toStrictEqual(startOperationResult);
+        });
+
         it("should execute operation and ignore healthcheck on any other status", async () => {
 
             // given
-            deploymentDefinitionServiceMock.getDeployment.withArgs(deploymentAttributes.deployment)
-                .resolves(extendedDeployment);
+            deploymentInstanceResolver.resolveInstances.withArgs(deploymentAttributes)
+                .resolves([extendedDeployment]);
             lifecycleServiceMock.start.withArgs(extendedDeployment)
                 .resolves(startFailureOperationResult);
 
@@ -151,8 +235,8 @@ describe("Unit tests for DeploymentFacade", () => {
         it("should execute operation", async () => {
 
             // given
-            deploymentDefinitionServiceMock.getDeployment.withArgs(deploymentAttributes.deployment)
-                .resolves(extendedDeployment);
+            deploymentInstanceResolver.resolveInstances.withArgs(deploymentAttributes)
+                .resolves([extendedDeployment]);
             lifecycleServiceMock.stop.withArgs(extendedDeployment)
                 .resolves(stopOperationResult);
 
@@ -169,8 +253,8 @@ describe("Unit tests for DeploymentFacade", () => {
         it("should execute operation and attempt healthcheck on UNKNOWN_STARTED status", async () => {
 
             // given
-            deploymentDefinitionServiceMock.getDeployment.withArgs(deploymentAttributes.deployment)
-                .resolves(extendedDeployment);
+            deploymentInstanceResolver.resolveInstances.withArgs(deploymentAttributes)
+                .resolves([extendedDeployment]);
             lifecycleServiceMock.restart.withArgs(extendedDeployment)
                 .resolves(unknownStartedOperationResult);
             healthcheckProviderMock.executeHealthcheck.withArgs(extendedDeployment.id, extendedDeployment.healthcheck)
@@ -186,8 +270,8 @@ describe("Unit tests for DeploymentFacade", () => {
         it("should execute operation and ignore healthcheck on any other status", async () => {
 
             // given
-            deploymentDefinitionServiceMock.getDeployment.withArgs(deploymentAttributes.deployment)
-                .resolves(extendedDeployment);
+            deploymentInstanceResolver.resolveInstances.withArgs(deploymentAttributes)
+                .resolves([extendedDeployment]);
             lifecycleServiceMock.restart.withArgs(extendedDeployment)
                 .resolves(startFailureOperationResult);
 
@@ -198,6 +282,48 @@ describe("Unit tests for DeploymentFacade", () => {
             expect(result).toStrictEqual(startFailureOperationResult);
 
             sinon.assert.notCalled(healthcheckProviderMock.executeHealthcheck);
+        });
+    });
+
+    describe("Additional test scenarios for OperationQueue", () => {
+
+        it("should throw error on requesting last operation result before executing the queue", () => {
+
+            // given
+            const notStartedQueue = OperationQueue.create("test");
+
+            // when
+            const failingCall = () => notStartedQueue.lastOperationResult;
+
+            // then
+            expect(failingCall).toThrow("No lifecycle operation result available for deployment [test]");
+        });
+
+        it("should throw error on executing the queue before populating it", async () => {
+
+            // given
+            const emptyQueue = OperationQueue.create("test");
+
+            // when
+            const failingCall = () => emptyQueue.execute();
+
+            // then
+            await expect(failingCall).rejects.toThrow("No lifecycle operations to execute");
+        });
+
+        it("should throw error on executing the queue with an empty step in it", async () => {
+
+            // given
+            const invalidQueue = OperationQueue.create("test");
+            invalidQueue.enqueue(() => Promise.resolve(startOperationResult));
+            // @ts-ignore
+            invalidQueue.enqueue(null);
+
+            // when
+            const failingCall = () => invalidQueue.execute();
+
+            // then
+            await expect(failingCall).rejects.toThrow("Lifecycle operation not found");
         });
     });
 });

--- a/modules/coordinator/tests/coordinator/core/service/instances/deployment-instance-resolver.test.ts
+++ b/modules/coordinator/tests/coordinator/core/service/instances/deployment-instance-resolver.test.ts
@@ -1,0 +1,291 @@
+import { DeploymentAttributes } from "@coordinator/core/domain";
+import { DeploymentValidationError, UnknownDeploymentError } from "@coordinator/core/error/error-types";
+import { DeploymentDefinitionService } from "@coordinator/core/service/deployment-definition-service";
+import { DeploymentInstanceResolver } from "@coordinator/core/service/instances/deployment-instance-resolver";
+import { MultiInstanceRequestValidator } from "@coordinator/core/service/instances/multi-instance-request-validator";
+import { ExtendedDeployment } from "@coordinator/web/model/deployment";
+import {
+    Deployment,
+    DockerExecutionType,
+    InstanceNamingStrategy,
+    InstanceSpreadMode,
+    SourceType
+} from "@core-lib/platform/api/deployment";
+import sinon, { SinonStubbedInstance } from "sinon";
+
+describe("Unit tests for DeploymentInstanceResolver", () => {
+
+    let deploymentDefinitionServiceMock: SinonStubbedInstance<DeploymentDefinitionService>;
+    let multiInstanceValidator: SinonStubbedInstance<MultiInstanceRequestValidator>;
+    let deploymentInstanceResolver: DeploymentInstanceResolver;
+
+    beforeEach(() => {
+        deploymentDefinitionServiceMock = sinon.createStubInstance(DeploymentDefinitionService);
+        multiInstanceValidator = sinon.createStubInstance(MultiInstanceRequestValidator);
+        deploymentInstanceResolver = new DeploymentInstanceResolver(deploymentDefinitionServiceMock, multiInstanceValidator);
+    });
+
+    type Scenario = {
+        network: "bridged" | "host",
+        targetHostCount: number,
+        targetInstanceCount: number,
+        spreadMode: "replicated" | "one-per-host",
+        suffix: "incremental" | "predefined",
+        predefinedSuffixes: string[],
+        expectations: ((scenario: Scenario) => Deployment)[],
+        includePortInHealthCheckEndpoint?: boolean
+    }
+
+    function scenario(network: "bridged" | "host", targetHostCount: number,
+                      targetInstanceCount: number, spreadMode: "replicated" | "one-per-host",
+                      suffix: "incremental" | "predefined", predefinedSuffixes: string[],
+                      expectations: ((scenario: Scenario) => Deployment)[], includePortInHealthCheckEndpoint: boolean = true): Scenario {
+
+        return { network, targetHostCount, targetInstanceCount, spreadMode, suffix, predefinedSuffixes, expectations, includePortInHealthCheckEndpoint };
+    }
+
+    describe("Test scenarios for #resolveSingleInstance", () => {
+
+        it("should return the requested single-instance deployment", async () => {
+
+            // given
+            const id = "myapp";
+            const attributes = { deployment: id, roll: false };
+            const deployment = { target: { multiInstance: { enabled: false } } } as ExtendedDeployment;
+
+            deploymentDefinitionServiceMock.getDeployment.withArgs(id, false).resolves(deployment);
+
+            // when
+            const result = await deploymentInstanceResolver.resolveSingleInstance(attributes);
+
+            // then
+            expect(result).toBe(deployment);
+        });
+
+        it("should return the requested instance of multi-instance deployment", async () => {
+
+            // given
+            const id = "myapp";
+            const attributes = { deployment: id, roll: false, instance: "standby-1" };
+            const singleInstanceScenario = scenario("bridged", 1, 3, "replicated", "predefined", ["primary", "standby-1", "standby-2"], [
+                alignedDeployment("myapp-container-primary", {}, { "8000": "8000" }, ["host-1"], "http://localhost/health"),
+                alignedDeployment("myapp-container-standby-1", {}, { "8100": "8000" }, ["host-1"], "http://localhost/health"),
+                alignedDeployment("myapp-container-standby-2", {}, { "8200": "8000" }, ["host-1"], "http://localhost/health"),
+            ], false);
+            const deployment = sourceDeployment(singleInstanceScenario);
+            const expectedDeployment = singleInstanceScenario.expectations
+                .map(expectation => expectation(singleInstanceScenario))[1];
+
+            deploymentDefinitionServiceMock.getDeployment.withArgs(id, false).resolves(deployment);
+
+            // when
+            const result = await deploymentInstanceResolver.resolveSingleInstance(attributes);
+
+            // then
+            expect(result).toEqual(expectedDeployment);
+            expect(result.execution.commandName).toEqual("myapp-container-standby-1");
+        });
+
+        it("should throw error on missing deployment", async () => {
+
+            // given
+            const id = "myapp";
+            const attributes = { deployment: id, roll: false };
+
+            deploymentDefinitionServiceMock.getDeployment.withArgs(id, false).rejects(new UnknownDeploymentError(id));
+
+            // when
+            const failingCall = () => deploymentInstanceResolver.resolveSingleInstance(attributes);
+
+            // then
+            await expect(failingCall).rejects.toThrow(UnknownDeploymentError);
+        });
+
+        it("should throw error on multiple resolved deployments", async () => {
+
+            // given
+            const id = "myapp";
+            const attributes = { deployment: id, roll: true };
+            const singleInstanceScenario = scenario("bridged", 1, 3, "replicated", "predefined", ["primary", "standby-1", "standby-2"], [
+                alignedDeployment("myapp-container-primary", {}, { "8000": "8000" }, ["host-1"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-standby-1", {}, { "8100": "8000" }, ["host-1"], "http://localhost:8100/health"),
+                alignedDeployment("myapp-container-standby-2", {}, { "8200": "8000" }, ["host-1"], "http://localhost:8200/health"),
+            ]);
+            const deployment = sourceDeployment(singleInstanceScenario);
+
+            deploymentDefinitionServiceMock.getDeployment.withArgs(id, false).resolves(deployment);
+
+            // when
+            const failingCall = () => deploymentInstanceResolver.resolveSingleInstance(attributes);
+
+            // then
+            await expect(failingCall).rejects.toThrow(DeploymentValidationError);
+            await expect(failingCall).rejects.toThrow("Requested lifecycle operation for deployment myapp with attributes [roll=true; instance=undefined] is not supported: Expected single resolved instance, got 3");
+        });
+    });
+
+    describe("Test scenarios for #resolveInstances", () => {
+
+        const scenarios: Scenario[] = [
+            scenario("bridged", 1, 4, "replicated", "incremental", [], [
+                alignedDeployment("myapp-container-0", {}, { "8000": "8000" }, ["host-1"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-1", {}, { "8100": "8000" }, ["host-1"], "http://localhost:8100/health"),
+                alignedDeployment("myapp-container-2", {}, { "8200": "8000" }, ["host-1"], "http://localhost:8200/health"),
+                alignedDeployment("myapp-container-3", {}, { "8300": "8000" }, ["host-1"], "http://localhost:8300/health")
+            ]),
+            scenario("bridged", 1, 3, "replicated", "predefined", ["primary", "standby-1", "standby-2"], [
+                alignedDeployment("myapp-container-primary", {}, { "8000": "8000" }, ["host-1"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-standby-1", {}, { "8100": "8000" }, ["host-1"], "http://localhost:8100/health"),
+                alignedDeployment("myapp-container-standby-2", {}, { "8200": "8000" }, ["host-1"], "http://localhost:8200/health"),
+            ]),
+            scenario("host", 1, 2, "replicated", "incremental", [], [
+                alignedDeployment("myapp-container-0", { INSTANCE_PORT: "8000" }, {}, ["host-1"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-1", { INSTANCE_PORT: "8100" }, {}, ["host-1"], "http://localhost:8100/health")
+            ]),
+            scenario("host", 1, 2, "replicated", "predefined", ["primary", "standby"], [
+                alignedDeployment("myapp-container-primary", { INSTANCE_PORT: "8000" }, {}, ["host-1"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-standby", { INSTANCE_PORT: "8100" }, {}, ["host-1"], "http://localhost:8100/health")
+            ]),
+
+            scenario("bridged", 2, 2, "replicated", "incremental", [], [
+                alignedDeployment("myapp-container-0", {}, { "8000": "8000" }, ["host-1"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-0", {}, { "8000": "8000" }, ["host-2"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-1", {}, { "8100": "8000" }, ["host-1"], "http://localhost:8100/health"),
+                alignedDeployment("myapp-container-1", {}, { "8100": "8000" }, ["host-2"], "http://localhost:8100/health")
+            ]),
+            scenario("host", 3, 3, "replicated", "predefined", ["primary", "standby-1", "standby-2"], [
+                alignedDeployment("myapp-container-primary", { INSTANCE_PORT: "8000" }, {}, ["host-1"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-primary", { INSTANCE_PORT: "8000" }, {}, ["host-2"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-primary", { INSTANCE_PORT: "8000" }, {}, ["host-3"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-standby-1", { INSTANCE_PORT: "8100" }, {}, ["host-1"], "http://localhost:8100/health"),
+                alignedDeployment("myapp-container-standby-1", { INSTANCE_PORT: "8100" }, {}, ["host-2"], "http://localhost:8100/health"),
+                alignedDeployment("myapp-container-standby-1", { INSTANCE_PORT: "8100" }, {}, ["host-3"], "http://localhost:8100/health"),
+                alignedDeployment("myapp-container-standby-2", { INSTANCE_PORT: "8200" }, {}, ["host-1"], "http://localhost:8200/health"),
+                alignedDeployment("myapp-container-standby-2", { INSTANCE_PORT: "8200" }, {}, ["host-2"], "http://localhost:8200/health"),
+                alignedDeployment("myapp-container-standby-2", { INSTANCE_PORT: "8200" }, {}, ["host-3"], "http://localhost:8200/health")
+            ]),
+            scenario("bridged", 3, 3, "one-per-host", "incremental", [], [
+                alignedDeployment("myapp-container-0", {}, { "8000": "8000" }, ["host-1"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-1", {}, { "8000": "8000" }, ["host-2"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-2", {}, { "8000": "8000" }, ["host-3"], "http://localhost:8000/health")
+            ]),
+            scenario("host", 2, 2, "one-per-host", "predefined", ["primary", "standby-1"], [
+                alignedDeployment("myapp-container-primary", {}, {}, ["host-1"], "http://localhost:8000/health"),
+                alignedDeployment("myapp-container-standby-1", {}, {}, ["host-2"], "http://localhost:8000/health")
+            ])
+        ];
+
+        scenarios.forEach(scenario => {
+            it(`should resolve instance for deployment with: ${formatScenario(scenario)}`, async () => {
+
+                // given
+                const deployment = sourceDeployment(scenario);
+                const deploymentAttributes: DeploymentAttributes = { deployment: "app", roll: true };
+                const expectations = scenario.expectations.map(expectation => expectation(scenario));
+
+                deploymentDefinitionServiceMock.getDeployment.withArgs("app", false).resolves(deployment);
+
+                // when
+                const result = await deploymentInstanceResolver.resolveInstances(deploymentAttributes);
+
+                // then
+                expect(result).toEqual(expectations);
+            });
+        });
+        
+        function formatScenario(scenario: Scenario): string {
+            return `network=${scenario.network} | targetHostCount=${scenario.targetHostCount} | targetInstanceCount=${scenario.targetInstanceCount} `
+                + `| spreadMode=${scenario.spreadMode} | suffix=${scenario.suffix} | predefinedSuffixes=${scenario.predefinedSuffixes.join(",")}`;
+        }
+    });
+
+    function sourceDeployment(scenario: Scenario): ExtendedDeployment {
+
+        return {
+            id: "myapp",
+            source: {
+                type: SourceType.DOCKER,
+                home: "localhost:9000/apps",
+                resource: "myapp-image"
+            },
+            target: {
+                hosts: Array.from({ length: scenario.targetHostCount }, (_, index) => `host-${index + 1}`),
+                multiInstance: {
+                    enabled: true,
+                    spreadMode: scenario.spreadMode === "replicated"
+                        ? InstanceSpreadMode.REPLICATE
+                        : InstanceSpreadMode.ONE_PER_HOST,
+                    namingStrategy: scenario.suffix === "incremental"
+                        ? InstanceNamingStrategy.INCREMENTAL_SUFFIX
+                        : InstanceNamingStrategy.CUSTOM_PREDEFINED,
+                    hostNetworkBasePort: scenario.network === "host"
+                        ? 8000
+                        : undefined,
+                    instanceCount: scenario.targetInstanceCount,
+                    definedNames: scenario.predefinedSuffixes,
+                    portOffset: 100
+                }
+            },
+            execution: {
+                via: DockerExecutionType.STANDARD,
+                commandName: "myapp-container",
+                args: {
+                    environment: {
+                        APP_PROFILE: "test"
+                    },
+                    ports: scenario.network === "bridged"
+                        ? { "8000": "8000" }
+                        : {}
+                }
+            },
+            healthcheck: {
+                enabled: true,
+                endpoint: scenario.includePortInHealthCheckEndpoint
+                    ? "http://localhost:8000/health"
+                    : "http://localhost/health",
+                delay: 5000,
+                timeout: 3000,
+                maxAttempts: 3
+            },
+            info: {
+                enabled: false
+            },
+            metadata: {
+                locked: true,
+                createdAt: new Date("2026-06-10T17:00:00.000Z"),
+                updatedAt: new Date("2026-06-11T18:00:00.000Z")
+            }
+        };
+    }
+
+    function alignedDeployment(commandName: string, environment: Record<string, string>, ports: Record<string, string>,
+                               hosts: string[], healthCheckEndpoint: string): (_: Scenario) => ExtendedDeployment {
+
+        return (scenario) => {
+
+            const deployment = sourceDeployment(scenario);
+
+            return {
+                ...deployment,
+                target: {
+                    ...deployment.target,
+                    hosts
+                },
+                execution: {
+                    ...deployment.execution,
+                    commandName,
+                    args: {
+                        ...deployment.execution.args,
+                        environment: { APP_PROFILE: "test", ...environment },
+                        ports
+                    }
+                },
+                healthcheck: {
+                    ...deployment.healthcheck,
+                    endpoint: healthCheckEndpoint
+                },
+                metadata: structuredClone(deployment.metadata)
+            }
+        };
+    }
+});

--- a/modules/coordinator/tests/coordinator/core/service/instances/multi-instance-config-validator.test.ts
+++ b/modules/coordinator/tests/coordinator/core/service/instances/multi-instance-config-validator.test.ts
@@ -1,0 +1,118 @@
+import { MultiInstanceConfigValidator } from "@coordinator/core/service/instances/multi-instance-config-validator";
+import { Deployment, InstanceNamingStrategy, InstanceSpreadMode, SourceType } from "@core-lib/platform/api/deployment";
+
+describe("Unit tests for MultiInstanceConfigValidator", () => {
+
+    let multiInstanceConfigValidator: MultiInstanceConfigValidator;
+
+    beforeEach(() => {
+        multiInstanceConfigValidator = new MultiInstanceConfigValidator();
+    });
+
+    describe("Test scenarios for #validateDeploymentDefinition", () => {
+
+        type Scenario = { deployment: Deployment };
+
+        const scenarios: Scenario[] = [
+            { deployment: { target: { hosts: ["host-1"], multiInstance: { enabled: false } } } as Deployment },
+            { deployment: deployment("host", 3, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.INCREMENTAL_SUFFIX, 1000, undefined, 8080) },
+            { deployment: deployment("bridge", 3, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.INCREMENTAL_SUFFIX, 1000) },
+            { deployment: deployment("host", 3, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.CUSTOM_PREDEFINED, 1000, ["instance-1", "instance-2", "instance-3"], 8080) },
+            { deployment: deployment("bridge", 2, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.CUSTOM_PREDEFINED, 100, ["primary", "standby"]) },
+            { deployment: deployment("bridge", 2, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.INCREMENTAL_SUFFIX, 500) },
+            { deployment: deployment("host", 2, InstanceSpreadMode.ONE_PER_HOST, InstanceNamingStrategy.INCREMENTAL_SUFFIX, 0, undefined, 8080) },
+            { deployment: deployment("bridge", 2, InstanceSpreadMode.ONE_PER_HOST, InstanceNamingStrategy.CUSTOM_PREDEFINED, 100, ["primary", "secondary"]) }
+        ];
+
+        scenarios.forEach(scenario => {
+            it(`should consider the configuration valid for ${JSON.stringify(scenario.deployment)}`, () => {
+
+                // when
+                multiInstanceConfigValidator.validateDeploymentDefinition(scenario.deployment);
+
+                // then
+                // silent fallthrough expected
+            });
+        });
+
+        type InvalidScenario = { deployment: Deployment, expectedError: string };
+
+        const invalidScenarios: InvalidScenario[] = [
+            {
+                deployment: {
+                    source: { type: SourceType.FILESYSTEM },
+                    target: { multiInstance: { enabled: true, instanceCount: 2 } }
+                } as Deployment, expectedError: "Multi-instance deployments are only supported for Docker deployments"
+            },
+            {
+                deployment: {
+                    target: { hosts: ["host-1", "host-2"], multiInstance: { enabled: false } }
+                } as Deployment, expectedError: "Multi-instance deployment must be enabled for multi-host deployments"
+            },
+            {
+                deployment: deployment("host", 1, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.INCREMENTAL_SUFFIX, 1000, undefined, 8080),
+                expectedError: "Instance count must be at least 2 for multi-instance deployments"
+            },
+            {
+                deployment: deployment("host", 3, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.CUSTOM_PREDEFINED, 1000, ["instance-1", "instance-2"], 8080),
+                expectedError: "Number of custom predefined instance names must match the instance count"
+            },
+            {
+                deployment: deployment("host", 3, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.CUSTOM_PREDEFINED, 1000, ["instance-1", "instance-1", "instance-2"], 8080),
+                expectedError: "Custom predefined instance names must be unique"
+            },
+            {
+                deployment: deployment("host", 3, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.INCREMENTAL_SUFFIX, 1000, ["instance-1"], 8080),
+                expectedError: "Defined names must not be defined for incremental naming strategy"
+            },
+            {
+                deployment: deployment("host", 3, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.INCREMENTAL_SUFFIX, 1000),
+                expectedError: "Host network base port must be defined for host network mode"
+            },
+            {
+                deployment: deployment("bridge", 3, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.INCREMENTAL_SUFFIX, 1000, undefined, 8080),
+                expectedError: "Host network base port must not be defined for bridged network mode"
+            },
+            {
+                deployment: deployment("host", 3, InstanceSpreadMode.REPLICATE, InstanceNamingStrategy.INCREMENTAL_SUFFIX, 0, undefined, 8080),
+                expectedError: "Port offset must be defined for host replication spread mode"
+            },
+            {
+                deployment: deployment("host", 3, InstanceSpreadMode.ONE_PER_HOST, InstanceNamingStrategy.INCREMENTAL_SUFFIX, 0, undefined, 8080),
+                expectedError: "Instance count must match the number of hosts for one-per-host spread mode"
+            }
+        ];
+
+        invalidScenarios.forEach(scenario => {
+            it(`should throw error for invalid configuration: ${scenario.expectedError}`, () => {
+
+                // when
+                const validation = () => multiInstanceConfigValidator.validateDeploymentDefinition(scenario.deployment);
+
+                // then
+                expect(validation).toThrow(scenario.expectedError);
+            });
+        });
+
+
+        function deployment(networkMode: string, instanceCount: number, 
+                            spreadMode: InstanceSpreadMode, namingStrategy: InstanceNamingStrategy, 
+                            portOffset: number, definedNames?: string[], 
+                            hostNetworkBasePort?: number): Deployment {
+            
+            return {
+                source: { type: SourceType.DOCKER },
+                target: {
+                    multiInstance: { 
+                        enabled: true, instanceCount, spreadMode, namingStrategy, 
+                        portOffset, definedNames, hostNetworkBasePort
+                    },
+                    hosts: ["host1", "host2"]
+                },
+                execution: {
+                    args: { networkMode }
+                }
+            } as Deployment;
+        }
+    });
+});

--- a/modules/coordinator/tests/coordinator/core/service/instances/multi-instance-request-validator.test.ts
+++ b/modules/coordinator/tests/coordinator/core/service/instances/multi-instance-request-validator.test.ts
@@ -1,0 +1,128 @@
+import { DeploymentAttributes } from "@coordinator/core/domain";
+import { DeploymentValidationError } from "@coordinator/core/error/error-types";
+import { MultiInstanceRequestValidator } from "@coordinator/core/service/instances/multi-instance-request-validator";
+import { Deployment, InstanceNamingStrategy } from "@core-lib/platform/api/deployment";
+
+describe("Unit tests for MultiInstanceRequestValidator", () => {
+
+    let multiInstanceRequestValidator: MultiInstanceRequestValidator;
+
+    beforeEach(() => {
+        multiInstanceRequestValidator = new MultiInstanceRequestValidator();
+    });
+
+    describe("Test scenarios for #validateLifecycleRequest", () => {
+
+        type Scenario = { deployment: Deployment, attributes: DeploymentAttributes, errorMessage?: string };
+
+        const positiveScenarios: Scenario[] = [
+            {
+                deployment: deployment(true, InstanceNamingStrategy.INCREMENTAL_SUFFIX, []),
+                attributes: deploymentAttributes(true)
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.INCREMENTAL_SUFFIX, []),
+                attributes: deploymentAttributes(false, "0")
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.INCREMENTAL_SUFFIX, []),
+                attributes: deploymentAttributes(false, "1")
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.CUSTOM_PREDEFINED, ["live"]),
+                attributes: deploymentAttributes(true)
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.CUSTOM_PREDEFINED, ["primary", "secondary"]),
+                attributes: deploymentAttributes(false, "primary")
+            }
+        ];
+
+        positiveScenarios.forEach(scenario => {
+
+            it(`should consider request valid for deployment=${JSON.stringify(scenario)}`, async () => {
+
+                // when
+                multiInstanceRequestValidator.validateLifecycleRequest(scenario.attributes, scenario.deployment);
+
+                // then
+                // silent fallthrough expected
+            });
+        });
+
+        const negativeScenarios: Scenario[] = [
+            {
+                deployment: deployment(false, InstanceNamingStrategy.INCREMENTAL_SUFFIX, []),
+                attributes: deploymentAttributes(true),
+                errorMessage: "Requested lifecycle operation for deployment app with attributes [roll=true; instance=undefined] is not supported: Multi-instance deployment is not enabled for this deployment"
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.INCREMENTAL_SUFFIX, []),
+                attributes: deploymentAttributes(false),
+                errorMessage: "Requested lifecycle operation for deployment app with attributes [roll=false; instance=undefined] is not supported: Multi-instance deployment attribute is expected for this deployment"
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.INCREMENTAL_SUFFIX, []),
+                attributes: deploymentAttributes(true, "1"),
+                errorMessage: "Requested lifecycle operation for deployment app with attributes [roll=true; instance=1] is not supported: Rolling all instances and an exact instance at once is not possible"
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.CUSTOM_PREDEFINED, ["live"]),
+                attributes: deploymentAttributes(true, "live"),
+                errorMessage: "Requested lifecycle operation for deployment app with attributes [roll=true; instance=live] is not supported: Rolling all instances and an exact instance at once is not possible"
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.INCREMENTAL_SUFFIX, []),
+                attributes: deploymentAttributes(false, "primary"),
+                errorMessage: "Requested lifecycle operation for deployment app with attributes [roll=false; instance=primary] is not supported: Requested instance suffix is not valid for this deployment"
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.INCREMENTAL_SUFFIX, []),
+                attributes: deploymentAttributes(false, "2"),
+                errorMessage: "Requested lifecycle operation for deployment app with attributes [roll=false; instance=2] is not supported: Requested instance suffix is not valid for this deployment"
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.INCREMENTAL_SUFFIX, []),
+                attributes: deploymentAttributes(false, "3"),
+                errorMessage: "Requested lifecycle operation for deployment app with attributes [roll=false; instance=3] is not supported: Requested instance suffix is not valid for this deployment"
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.INCREMENTAL_SUFFIX, []),
+                attributes: deploymentAttributes(false, "-1"),
+                errorMessage: "Requested lifecycle operation for deployment app with attributes [roll=false; instance=-1] is not supported: Requested instance suffix is not valid for this deployment"
+            },
+            {
+                deployment: deployment(true, InstanceNamingStrategy.CUSTOM_PREDEFINED, ["primary", "secondary"]),
+                attributes: deploymentAttributes(false, "unknown"),
+                errorMessage: "Requested lifecycle operation for deployment app with attributes [roll=false; instance=unknown] is not supported: Requested instance suffix is not valid for this deployment"
+            }
+        ];
+
+        negativeScenarios.forEach(scenario => {
+
+            it(`should consider request invalid for deployment=${JSON.stringify(scenario)}`, async () => {
+
+                // when
+                const failingCall = () => multiInstanceRequestValidator.validateLifecycleRequest(scenario.attributes, scenario.deployment);
+
+                // then
+                // exception expected
+                expect(failingCall).toThrow(DeploymentValidationError);
+                expect(failingCall).toThrow(scenario.errorMessage);
+            });
+        });
+    });
+
+    function deployment(enabled: boolean, namingStrategy: InstanceNamingStrategy, definedNames: string[]): Deployment {
+
+        return {
+            target: {
+                multiInstance: { enabled, namingStrategy, definedNames, instanceCount: 2 }
+            }
+        } as Deployment;
+    }
+
+    function deploymentAttributes(roll: boolean, instance?: string): DeploymentAttributes {
+        return { deployment: "app", roll, instance }
+    }
+});

--- a/modules/coordinator/tests/coordinator/core/socket/lifecycle-operation-registry.test.ts
+++ b/modules/coordinator/tests/coordinator/core/socket/lifecycle-operation-registry.test.ts
@@ -129,6 +129,7 @@ const wait = (timeout: number): Promise<void> => {
 }
 
 class LoggerStub {
-    warn(message: string): void {};
-    error(message: string): void {};
+    info(_: string): void {};
+    warn(_: string): void {};
+    error(_: string): void {};
 }

--- a/modules/platform-core/package.json
+++ b/modules/platform-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domino-platform/platform-core",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "scripts": {
     "test": "jest",
     "build": "tsc --build . && tsc-alias -p tsconfig.json"

--- a/modules/platform-core/src/lib/platform/api/deployment/index.ts
+++ b/modules/platform-core/src/lib/platform/api/deployment/index.ts
@@ -41,11 +41,35 @@ export interface DeploymentSource {
 }
 
 /**
- * Deployment target configuration parameters.
+ * Supported naming strategies.
  */
-export interface DeploymentTarget {
+export enum InstanceNamingStrategy {
 
-    hosts: string[];
+    INCREMENTAL_SUFFIX = "incremental-suffix",
+    CUSTOM_PREDEFINED = "custom-predefined"
+}
+
+/**
+ * Supported multi-instance spread modes.
+ */
+export enum InstanceSpreadMode {
+
+    ONE_PER_HOST = "one-per-host",
+    REPLICATE = "replicate"
+}
+
+/**
+ * Multi-instance configuration parameters.
+ */
+export interface MultiInstanceDeployment {
+
+    enabled: boolean;
+    instanceCount: number;
+    spreadMode: InstanceSpreadMode;
+    namingStrategy: InstanceNamingStrategy;
+    definedNames?: string[];
+    portOffset: number;
+    hostNetworkBasePort?: number;
 }
 
 /**
@@ -89,7 +113,7 @@ export interface DeploymentInfo {
 }
 
 /**
- * Deployment healthcheck configuration parameters.
+ * Deployment health check configuration parameters.
  */
 export interface DeploymentHealthcheck {
 
@@ -120,7 +144,21 @@ export type OptionalDeploymentInfo = (EnabledDeploymentOperation & DeploymentInf
 export type OptionalDeploymentHealthcheck = (EnabledDeploymentOperation & DeploymentHealthcheck) | DisabledDeploymentOperation;
 
 /**
- * Deployment configuration mapping a complete deployment entry..
+ * MultiInstanceDeployment configuration combined with the enabled/disabled flag.
+ */
+export type OptionalMultiInstanceDeployment = (EnabledDeploymentOperation & MultiInstanceDeployment) | DisabledDeploymentOperation;
+
+/**
+ * Deployment target configuration parameters.
+ */
+export interface DeploymentTarget {
+
+    hosts: string[];
+    multiInstance?: OptionalMultiInstanceDeployment;
+}
+
+/**
+ * Deployment configuration, mapping a complete deployment entry.
  */
 export interface Deployment {
 

--- a/modules/platform-core/src/lib/platform/config/index.ts
+++ b/modules/platform-core/src/lib/platform/config/index.ts
@@ -75,7 +75,10 @@ export abstract class ConfigurationModule<T, CK extends string> {
      * @protected can only be used by concrete implementations
      */
     protected getNode(parameters: MapNode, node: CK): MapNode {
-        return parameters?.get(node) as MapNode;
+
+        return parameters?.has(node)
+            ? parameters?.get(node) as MapNode
+            : undefined;
     }
 
     /**


### PR DESCRIPTION
 - Implemented support for multi-instance deployments
 - Aligned deployment definition API
 - Aligned unit tests
 - Added documentation for the new configuration parameters
 - Bumped Platform Core version to 1.3.0
 - Bumped Coordinator version to 2.5.0-dev